### PR TITLE
Use multithreading for searches

### DIFF
--- a/quasarr/providers/version.py
+++ b/quasarr/providers/version.py
@@ -6,7 +6,7 @@ import re
 
 
 def get_version():
-    return "0.1.7"
+    return "0.1.8"
 
 
 def create_version_file():

--- a/quasarr/search/__init__.py
+++ b/quasarr/search/__init__.py
@@ -2,6 +2,8 @@
 # Quasarr
 # Project by https://github.com/rix1337
 
+from concurrent.futures import ThreadPoolExecutor, as_completed
+
 from quasarr.search.sources.dw import dw_feed, dw_search
 from quasarr.search.sources.fx import fx_feed, fx_search
 from quasarr.search.sources.nx import nx_feed, nx_search
@@ -14,20 +16,30 @@ def get_search_results(shared_state, request_from, imdb_id=None):
     fx = shared_state.values["config"]("Hostnames").get("fx")
     nx = shared_state.values["config"]("Hostnames").get("nx")
 
+    functions = []
     if imdb_id:
         if dw:
-            results.extend(dw_search(shared_state, request_from, imdb_id))
+            functions.append(lambda: dw_search(shared_state, request_from, imdb_id))
         if fx:
-            results.extend(fx_search(shared_state, imdb_id))
+            functions.append(lambda: fx_search(shared_state, imdb_id))
         if nx:
-            results.extend(nx_search(shared_state, request_from, imdb_id))
+            functions.append(lambda: nx_search(shared_state, request_from, imdb_id))
     else:
         if dw:
-            results.extend(dw_feed(shared_state, request_from))
+            functions.append(lambda: dw_feed(shared_state, request_from))
         if fx:
-            results.extend(fx_feed(shared_state))
+            functions.append(lambda: fx_feed(shared_state))
         if nx:
-            results.extend(nx_feed(shared_state, request_from))
+            functions.append(lambda: nx_feed(shared_state, request_from))
+
+    with ThreadPoolExecutor() as executor:
+        futures = [executor.submit(func) for func in functions]
+        for future in as_completed(futures):
+            try:
+                result = future.result()
+                results.extend(result)
+            except Exception as e:
+                print(f"An error occurred: {e}")
 
     print(f"Providing {len(results)} releases to {request_from}")
     return results


### PR DESCRIPTION
This yields a speedup of at least 2x when using multiple hostnames.