### PR TITLE
Fix #31 - Update XML handling and escape titles, bump version to 0.3.4

### DIFF
--- a/quasarr/arr/__init__.py
+++ b/quasarr/arr/__init__.py
@@ -5,9 +5,10 @@
 import json
 import re
 import traceback
+import xml.sax.saxutils as sax_utils
 from base64 import urlsafe_b64decode
 from datetime import datetime
-from xml.etree import ElementTree as ET
+from xml.etree import ElementTree as element_tree
 
 import requests
 from bottle import Bottle, request, response, abort
@@ -259,7 +260,7 @@ def api(shared_state_dict, shared_state_lock):
         nzo_ids = []
         for upload in downloads:
             file_content = upload.file.read()
-            root = ET.fromstring(file_content)
+            root = element_tree.fromstring(file_content)
             title = root.find(".//file").attrib["title"]
             url = root.find(".//file").attrib["url"]
             size_mb = root.find(".//file").attrib["size_mb"]
@@ -425,7 +426,7 @@ def api(shared_state_dict, shared_state_lock):
                         release = release["details"]
                         items += f'''
                         <item>
-                            <title>{release["title"]}</title>
+                            <title>{sax_utils.escape(release["title"])}</title>
                             <guid isPermaLink="True">{release["link"]}</guid>
                             <link>{release["link"]}</link>
                             <comments>{release["source"]}</comments>

--- a/quasarr/providers/version.py
+++ b/quasarr/providers/version.py
@@ -6,7 +6,7 @@ import re
 
 
 def get_version():
-    return "0.3.3"
+    return "0.3.4"
 
 
 def create_version_file():


### PR DESCRIPTION
Replaced `xml.etree.ElementTree` alias for clarity and utilized `xml.sax.saxutils.escape` to properly escape XML titles. These changes enhance code maintainability and prevent potential XML injection issues. Incremented the version to 0.3.4 to reflect the updates.