### PR TITLE
Add hostname extraction via public URL and improve setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,18 +20,19 @@ Quasarr will confidently handle the rest.
 # Instructions
 
 * Follow instructions to :
-  * Set up at least one hostname for Quasarr to use
-    * You chose what hostnames to search - do your own research.
-    * Asking for hostnames on this GitHub repo is forbidden.
-    * Quasarr will become available once at least one suitable hostname is set.
-  * Provide your [MyJDownloader credentials](https://my.jdownloader.org)
+    * Set up at least one hostname for Quasarr to use
+        * Chose your own or use the `HOSTNAMES` variable to provide a list of hostnames.
+        * Always redact hostnames when creating issues in this repo.
+        * Quasarr will become available once at least one suitable hostname is set.
+    * Provide your [My-JDownloader-Credentials](https://my.jdownloader.org)
 * Set up Quasarr's URL as 'Newznab Indexer' and 'SABnzbd Download Client' in Sonarr/Radarr.
     * Leave settings at default
     * Use this API key: `quasarr`
 * As with other download clients, you must ensure the download path used by JDownloader is accessible to *arr.
 
 # Docker
-It is highly recommended to run the latest docker image with all optional Variables set.
+
+It is highly recommended to run the latest docker image with all optional variables set.
 
 ```
 docker run -d \
@@ -39,16 +40,22 @@ docker run -d \
   -p port:8080 \
   -v /path/to/config/:/config:rw \
   -e 'INTERNAL_ADDRESS'='http://192.168.0.1:8080' \
-  -e 'EXTERNAL_ADDRESS'='http://foo.bar/' \
+  -e 'EXTERNAL_ADDRESS'='https://foo.bar/' \
   -e 'DISCORD'='https://discord.com/api/webhooks/1234567890/ABCDEFGHIJKLMN' \
+  -e 'HOSTNAMES'='https://pastebin.com/raw/eX4Mpl3'
   rix1337/docker-quasarr:latest
   ```
 
 * `INTERNAL_ADDRESS` is required so Radarr/Sonarr can reach Quasarr. **Must** include port!
 * `EXTERNAL_ADDRESS` is optional and used in Discord notifications.
 * `DISCORD` is optional and must be a valid Discord Webhook URL.
+* `HOSTNAMES` is optional and allows skipping the Hostname setting on first launch.
+    * Must be a publicly available `HTTP` or `HTTPs` link
+    * Must be a raw `.ini` / text file (not html or json)
+    * Must contain at least one valid Hostname per line `ab = xyz`
 
 # Manual setup
+
 Use this only in case you cant run the docker image.
 
 `pip install quasarr`
@@ -59,8 +66,13 @@ Use this only in case you cant run the docker image.
 quasarr
   --port=8080
   --discord=https://discord.com/api/webhooks/1234567890/ABCDEFGHIJKLMN
-  --external_address=http://foo.bar/
+  --external_address=https://foo.bar/
+  --hostnames=https://pastebin.com/raw/eX4Mpl3
   ```
 
 * `--discord` must be a valid Discord Webhook URL and is optional.
 * `--external_address` is used in Discord notifications and is optional.
+* `--hostnames` is optional and allows skipping the manual hostname step during setup.
+    * Must be a publicly available `HTTP` or `HTTPs` link
+    * Must be a raw `.ini` / text file (not html or json)
+    * Must contain at least one valid Hostname per line `ab = xyz`

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -34,5 +34,6 @@ ENV DOCKER="true"
 ENV INTERNAL_ADDRESS=""
 ENV EXTERNAL_ADDRESS=""
 ENV DISCORD=""
+ENV HOSTNAMES=""
 
-ENTRYPOINT ["sh", "-c", "quasarr --port=8080 --internal_address=$INTERNAL_ADDRESS --external_address=$EXTERNAL_ADDRESS --discord=$DISCORD"]
+ENTRYPOINT ["sh", "-c", "quasarr --port=8080 --internal_address=$INTERNAL_ADDRESS --external_address=$EXTERNAL_ADDRESS --discord=$DISCORD --hostnames=$HOSTNAMES"]

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -8,6 +8,7 @@ services:
             - '/path/to/config/:/config:rw'
         environment:
             - 'INTERNAL_ADDRESS=http://192.168.1.1:8080'
-            - 'EXTERNAL_ADDRESS=http://foo.bar/'
+            - 'EXTERNAL_ADDRESS=https://foo.bar/'
             - 'DISCORD=https://discord.com/api/webhooks/1234567890/ABCDEFGHIJKLMN'
+            - 'EXTERNAL_ADDRESS=https://pastebin.com/raw/eX4Mpl3'
         image: 'rix1337/docker-quasarr:latest'

--- a/quasarr/providers/shared_state.py
+++ b/quasarr/providers/shared_state.py
@@ -4,6 +4,7 @@
 
 import os
 import time
+from urllib import parse
 
 from quasarr.providers.myjd_api import Myjdapi, TokenExpiredException, RequestTimeoutException, MYJDException, Jddevice
 from quasarr.storage.config import Config
@@ -273,3 +274,23 @@ def download_package(links, title, password, package_id):
     if not downloaded:
         print(f"Failed to start download for {title}: Linkgrabber timeout!")
     return downloaded
+
+
+def extract_valid_hostname(url, shorthand):
+    # Check if both characters from the shorthand appear in the url
+    try:
+        if '://' not in url:
+            url = 'http://' + url
+        result = parse.urlparse(url)
+        domain = result.netloc
+
+        # Check if both characters in the shorthand are in the domain
+        if all(char in domain for char in shorthand):
+            print(f"{domain} matches both characters from {shorthand}. Continuing...")
+            return domain
+        else:
+            print(f"Invalid domain {domain}: Does not contain both characters from shorthand {shorthand}")
+            return None
+    except Exception as e:
+        print(f"Error parsing URL {url}: {e}")
+        return None

--- a/quasarr/providers/version.py
+++ b/quasarr/providers/version.py
@@ -6,7 +6,7 @@ import re
 
 
 def get_version():
-    return "0.3.5"
+    return "0.4.0"
 
 
 def create_version_file():

--- a/quasarr/storage/config.py
+++ b/quasarr/storage/config.py
@@ -24,11 +24,8 @@ class Config(object):
         ],
         'Hostnames': [
             ("fx", "secret", ""),
-            ("sf", "secret", ""),
             ("dw", "secret", ""),
-            ("ff", "secret", ""),
-            ("nx", "secret", ""),
-            ("dd", "secret", "")
+            ("nx", "secret", "")
         ],
         'NX': [
             ("user", "secret", ""),


### PR DESCRIPTION
Introduce functionality to load and validate hostnames from a public URL, simplifying the initial setup. Refactor related code by centralizing domain extraction logic and updating configuration handling. Increment version to 0.3.6 to reflect these enhancements.