### PR TITLE
Improved package status logic

### DIFF
--- a/quasarr/providers/version.py
+++ b/quasarr/providers/version.py
@@ -6,7 +6,7 @@ import re
 
 
 def get_version():
-    return "0.9.6"
+    return "0.9.7"
 
 
 def create_version_file():


### PR DESCRIPTION
- Finished status now only applies to packages where every contained link is marked as such
- Previous implementation was buggy because it relied on the multi-line-response at the main package level