### PR TITLE
Add filter for desired mirror

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -46,6 +46,7 @@ body:
       description: |
         Add ALL messages from the log that correlate with your issue.
         Redact all hostnames you may have set.
+        If you can't see a log message that correlates with your issue, set the DEBUG environment variable to "true".
       render: text
     validations:
       required: true

--- a/README.md
+++ b/README.md
@@ -33,6 +33,11 @@ Quasarr will confidently handle the rest.
 * Set up Quasarr as `Newznab Indexer` and `SABnzbd Download Client` in Radarr/Sonarr
     * Use the API key from console output (or copy it from the Quasarr web UI)
     * Leave all other settings at default.
+    * If you prefer to only get releases for a specific mirror, add the mirror name to the
+      API path in the advanced indexer settings.
+      * Example: `/api/dropbox/` results will only return releases where `dropbox` is explicitly mentioned in link.
+      * This also means that if a mirror is not mentioned in the link, it will not be returned.
+      * Some hostnames never mention the mirror in the link, effectively disabling them, when using this feature.
 * To see download status information
     * Open `Activity` → `Queue` → `Options` in Radarr/Sonarr
     * Enable `Release Title`
@@ -94,10 +99,12 @@ amount of flexibility.
 I will not waste my precious time on features that will slow future development cycles down.
 Issues, feature and pull requests that are meant to introduce feature toggles will therefore be rejected.
 
-* If you need to update hostnames or My-JDownloader-Credentials, simply delete the config and restart Quasarr.
-* Radarr/Sonarr provide custom formats to automatically chose the most fitting release for a given search.
-* Quasarr will always prefix release titles with the source hostname in square brackets in case you want to apply
-  custom format scores to certain hostnames.
+Intentional design decisions are:
+* There is no settings UI after the initial setup.
+  If you need to update hostnames or My-JDownloader-Credentials, simply delete the `Quasarr.ini` and restart Quasarr.
+* Radarr and Sonarr provide custom formats to automatically choose the most fitting release for a given search
+  based on the release's title. Quasarr prefixes release titles with the source hostname in square brackets in case you
+  want to apply custom format scores to certain hostnames.
 
 # Roadmap
 
@@ -108,7 +115,6 @@ Issues, feature and pull requests that are meant to introduce feature toggles wi
     - Existing settings in Radarr/Sonarr
     - Existing settings in JDownloader
     - Existing tools from the *arr ecosystem that integrate directly with Radarr/Sonarr
-- Exposing the mirrors of a release to Radarr/Sonarr is a desired feature. This will allow scoring desired mirrors using custom profiles in Radarr/Sonarr. Quasarr will always provide all found mirrors at once, if they are protected by the same or no CAPTCHA.
 - There are no hostname integrations in active development.
 - Adding one or more hostnames focused on English content is highly desired.
   - Please provide suggestions in a private thread on Discord.

--- a/README.md
+++ b/README.md
@@ -36,8 +36,7 @@ Quasarr will confidently handle the rest.
     * If you prefer to only get releases for a specific mirror, add the mirror name to the
       API path in the advanced indexer settings.
       * Example: `/api/dropbox/` results will only return releases where `dropbox` is explicitly mentioned in link.
-      * This also means that if a mirror is not mentioned in the link, it will not be returned.
-      * Some hostnames never mention the mirror in the link, effectively disabling them, when using this feature.
+      * This means that if a mirror is not available at a hostname, the release will be ignored.
 * To see download status information
     * Open `Activity` → `Queue` → `Options` in Radarr/Sonarr
     * Enable `Release Title`
@@ -99,7 +98,7 @@ amount of flexibility.
 I will not waste my precious time on features that will slow future development cycles down.
 Issues, feature and pull requests that are meant to introduce feature toggles will therefore be rejected.
 
-Intentional design decisions are:
+## Intentional design decisions
 * There is no settings UI after the initial setup.
   If you need to update hostnames or My-JDownloader-Credentials, simply delete the `Quasarr.ini` and restart Quasarr.
 * Radarr and Sonarr provide custom formats to automatically choose the most fitting release for a given search
@@ -123,3 +122,24 @@ Intentional design decisions are:
     - Please follow the existing code style and project structure.
     - Anti-bot measures must be circumvented without relying on third party tools like Flaresolverr.
     - Please provide proof of functionality (screenshots/examples) when submitting your pull request.
+
+## Development Setup for Pull Requests
+
+To test your changes before submitting a pull request:
+
+### 1. Run Quasarr with the `--internal_address` parameter
+
+```bash
+python Quasarr.py --internal_address=http://<host-ip>:<port>
+```
+
+Replace `<host-ip>` and `<port>` with the scheme, IP, and port of your host machine.
+The `--internal_address` parameter is **mandatory**.
+
+### 2. Start the required services using the `dev-services-compose.yml` file
+
+```bash
+CONFIG_VOLUMES=/path/to/config docker-compose -f docker/dev-services-compose.yml up
+```
+
+Replace `/path/to/config` with your desired configuration location. The `CONFIG_VOLUMES` environment variable is **mandatory**.

--- a/docker/dev-services-compose.yml
+++ b/docker/dev-services-compose.yml
@@ -1,0 +1,58 @@
+services:
+  jdownloader:
+    image: jlesage/jdownloader-2
+    container_name: jdownloader
+    environment:
+      - TZ=Europe/Berlin
+      - CONFIG_VOLUMES=/config/volumes
+    ports:
+      - "9090:5800"
+      - "3129:3129"
+    volumes:
+      - ${CONFIG_VOLUMES}/jdownloader:/config
+      - ${CONFIG_VOLUMES}/downloads:/downloads
+    logging:
+      options:
+        max-size: "10m"
+        max-file: "1"
+    restart: unless-stopped
+
+  radarr:
+    image: lscr.io/linuxserver/radarr:latest
+    container_name: radarr
+    environment:
+      - PGID=1000
+      - PUID=1000
+      - TZ=Europe/Berlin
+      - CONFIG_VOLUMES=/config/volumes
+    ports:
+      - 9091:7878
+    volumes:
+      - ${CONFIG_VOLUMES}/radarr/config:/config
+      - ${CONFIG_VOLUMES}/radarr/movies:/movies
+      - ${CONFIG_VOLUMES}/downloads:/downloads
+    logging:
+      options:
+        max-size: "10m"
+        max-file: "1"
+    restart: unless-stopped
+
+  sonarr:
+    image: lscr.io/linuxserver/sonarr:latest
+    container_name: sonarr
+    environment:
+      - PGID=1000
+      - PUID=1000
+      - TZ=Europe/Berlin
+      - CONFIG_VOLUMES=/config/volumes
+    ports:
+      - 9092:8989
+    volumes:
+      - ${CONFIG_VOLUMES}/sonarr/config:/config
+      - ${CONFIG_VOLUMES}/sonarr/tv:/tv
+      - ${CONFIG_VOLUMES}/downloads:/downloads
+    logging:
+      options:
+        max-size: "10m"
+        max-file: "1"
+    restart: unless-stopped

--- a/quasarr/__init__.py
+++ b/quasarr/__init__.py
@@ -63,7 +63,7 @@ def run():
         else:
             if arguments.port:
                 port = int(arguments.port)
-            internal_address = f'http://{check_ip()}'
+            internal_address = f'http://{check_ip()}:{port}'
 
         if arguments.internal_address:
             internal_address = arguments.internal_address
@@ -194,7 +194,7 @@ def run():
         jdownloader.start()
 
         print("\n===== API Information =====")
-        print(f'Quasarr API now running at: "{shared_state.values['internal_address']}"')
+        print(f'Quasarr API now running at: "{shared_state.values['external_address']}"')
         print('Use the above URL to set up a "Newznab Indexer" and "SABnzbd Download Client" in Radarr/Sonarr')
         print(f'Leave all settings at default and use this API key: "{api_key}" (without quotes)')
 

--- a/quasarr/downloads/sources/dd.py
+++ b/quasarr/downloads/sources/dd.py
@@ -78,7 +78,7 @@ def retrieve_and_validate_session(shared_state):
     return dd_session
 
 
-def get_dd_download_links(shared_state, search_string):
+def get_dd_download_links(shared_state, mirror, search_string):
     dd = shared_state.values["config"]("Hostnames").get("dd")
 
     dd_session = retrieve_and_validate_session(shared_state)
@@ -122,6 +122,10 @@ def get_dd_download_links(shared_state, search_string):
                 elif release.get("release") == search_string:
                     filtered_links = []
                     for link in release["links"]:
+                        if mirror and mirror not in link["hostname"]:
+                            debug(f'Skipping link from "{link["hostname"]}" (not the desired mirror "{mirror}")!')
+                            continue
+
                         if any(
                                 existing_link["hostname"] == link["hostname"] and
                                 existing_link["url"].endswith(".mkv") and

--- a/quasarr/downloads/sources/dw.py
+++ b/quasarr/downloads/sources/dw.py
@@ -7,10 +7,10 @@ import re
 import requests
 from bs4 import BeautifulSoup
 
-from quasarr.providers.log import info
+from quasarr.providers.log import info, debug
 
 
-def get_dw_download_links(shared_state, url, title):
+def get_dw_download_links(shared_state, url, mirror, title):
     dw = shared_state.values["config"]("Hostnames").get("dw")
     ajax_url = "https://" + dw + "/wp-admin/admin-ajax.php"
 
@@ -52,6 +52,11 @@ def get_dw_download_links(shared_state, url, title):
                                 f'.html{match.group(2) if match.group(2) else ""}')
 
                 hoster = button.nextSibling.img["src"].split("/")[-1].replace(".png", "")
+                hoster = f"1{hoster}" if hoster.startswith("fichier") else hoster  # align with expected mirror name
+                if mirror and mirror not in hoster:
+                    debug(f'Skipping link from "{hoster}" (not the desired mirror "{mirror}")!')
+                    continue
+
                 download_links.append([link, hoster])
     except:
         info(f"DW site has been updated. Parsing download links for {title} not possible!")

--- a/quasarr/providers/version.py
+++ b/quasarr/providers/version.py
@@ -6,7 +6,7 @@ import re
 
 
 def get_version():
-    return "1.0.13"
+    return "1.1.0"
 
 
 def create_version_file():

--- a/quasarr/search/__init__.py
+++ b/quasarr/search/__init__.py
@@ -13,7 +13,7 @@ from quasarr.search.sources.nx import nx_feed, nx_search
 from quasarr.search.sources.sf import sf_feed, sf_search
 
 
-def get_search_results(shared_state, request_from, search_string="", season="", episode=""):
+def get_search_results(shared_state, request_from, search_string="", mirror=None, season="", episode=""):
     results = []
 
     dd = shared_state.values["config"]("Hostnames").get("dd")
@@ -32,26 +32,26 @@ def get_search_results(shared_state, request_from, search_string="", season="", 
             search_string = f"{search_string} S{int(season):02}"
 
         if dd:
-            functions.append(lambda: dd_search(shared_state, start_time, search_string))
+            functions.append(lambda: dd_search(shared_state, start_time, search_string, mirror=mirror))
         if dw:
-            functions.append(lambda: dw_search(shared_state, start_time, request_from, search_string))
+            functions.append(lambda: dw_search(shared_state, start_time, request_from, search_string, mirror=mirror))
         if fx:
-            functions.append(lambda: fx_search(shared_state, start_time, search_string))
+            functions.append(lambda: fx_search(shared_state, start_time, search_string, mirror=mirror))
         if nx:
-            functions.append(lambda: nx_search(shared_state, start_time, request_from, search_string))
+            functions.append(lambda: nx_search(shared_state, start_time, request_from, search_string, mirror=mirror))
         if sf:
-            functions.append(lambda: sf_search(shared_state, start_time, request_from, search_string))
+            functions.append(lambda: sf_search(shared_state, start_time, request_from, search_string, mirror=mirror))
     else:
         if dd:
-            functions.append(lambda: dd_search(shared_state, start_time))
+            functions.append(lambda: dd_search(shared_state, start_time, mirror=mirror))
         if dw:
-            functions.append(lambda: dw_feed(shared_state, start_time, request_from))
+            functions.append(lambda: dw_feed(shared_state, start_time, request_from, mirror=mirror))
         if fx:
-            functions.append(lambda: fx_feed(shared_state, start_time))
+            functions.append(lambda: fx_feed(shared_state, start_time, mirror=mirror))
         if nx:
-            functions.append(lambda: nx_feed(shared_state, start_time, request_from))
+            functions.append(lambda: nx_feed(shared_state, start_time, request_from, mirror=mirror))
         if sf:
-            functions.append(lambda: sf_feed(shared_state, start_time, request_from))
+            functions.append(lambda: sf_feed(shared_state, start_time, request_from, mirror=mirror))
 
     stype = f'search phrase "{search_string}"' if search_string else "feed search"
     info(f'Starting {len(functions)} search functions for {stype}... This may take some time.')

--- a/quasarr/search/sources/sf.py
+++ b/quasarr/search/sources/sf.py
@@ -9,19 +9,91 @@ from base64 import urlsafe_b64encode
 from datetime import datetime, timedelta
 
 import requests
-from bs4 import BeautifulSoup
 
 from quasarr.providers.imdb_metadata import get_localized_title
 from quasarr.providers.log import info, debug
 
+hostname = "sf"
+supported_mirrors = ["1fichier", "ddownload", "katfile", "rapidgator", "turbobit"]
 
-def sf_feed(shared_state, start_time, request_from):
+from bs4 import BeautifulSoup
+
+
+def parse_mirrors(base_url, entry):
+    """
+    entry: a BeautifulSoup Tag for <div class="entry">
+    returns a dict with:
+      - name:        header text
+      - season:      list of {host: link}
+      - episodes:    list of {number, title, links}
+    """
+
+    mirrors = {}
+
+    try:
+        host_map = {
+            '1F': '1fichier',
+            'DD': 'ddownload',
+            'KA': 'katfile',
+            'RG': 'rapidgator',
+            'TB': 'turbobit'
+        }
+
+        h3 = entry.select_one('h3')
+        name = h3.get_text(separator=' ', strip=True) if h3 else ''
+
+        season = {}
+        for a in entry.select('a.dlb.row'):
+            if a.find_parent('div.list.simple'):
+                continue
+            host = a.get_text(strip=True)
+            if len(host) > 2:  # episode hosts are 2 chars
+                season[host] = f"{base_url}{a['href']}"
+
+        episodes = []
+        for ep_row in entry.select('div.list.simple > div.row'):
+            if 'head' in ep_row.get('class', []):
+                continue
+
+            divs = ep_row.find_all('div', recursive=False)
+            number = int(divs[0].get_text(strip=True).rstrip('.'))
+            title = divs[1].get_text(strip=True)
+
+            ep_links = {}
+            for a in ep_row.select('div.row > a.dlb.row'):
+                host = a.get_text(strip=True)
+                full_host = host_map.get(host, host)
+                ep_links[full_host] = f"{base_url}{a['href']}"
+
+            episodes.append({
+                'number': number,
+                'title': title,
+                'links': ep_links
+            })
+
+        mirrors = {
+            'name': name,
+            'season': season,
+            'episodes': episodes
+        }
+    except Exception as e:
+        info(f"Error parsing mirrors: {e}")
+
+    return mirrors
+
+
+def sf_feed(shared_state, start_time, request_from, mirror=None):
     releases = []
-    sf = shared_state.values["config"]("Hostnames").get("sf")
+    sf = shared_state.values["config"]("Hostnames").get(hostname.lower())
     password = sf
 
     if "Radarr" in request_from:
-        debug(f"Skipped Radarr search (sf)")
+        debug(f'Skipping Radarr search on "{hostname.upper()}" (unsupported media type at hostname)!')
+        return releases
+
+    if mirror and mirror not in supported_mirrors:
+        debug(f'Mirror "{mirror}" not supported by "{hostname.upper()}". Supported mirrors: {supported_mirrors}.'
+              ' Skipping search!')
         return releases
 
     headers = {
@@ -37,9 +109,9 @@ def sf_feed(shared_state, start_time, request_from):
         date -= timedelta(days=1)
 
         try:
-            response = requests.get(f"https://serienfans.org/updates/{formatted_date}#list", headers, timeout=10)
+            response = requests.get(f"https://{sf}/updates/{formatted_date}#list", headers, timeout=10)
         except Exception as e:
-            info(f"Error loading SF feed: {e} for {formatted_date}")
+            info(f"Error loading {hostname.upper()} feed: {e} for {formatted_date}")
             return releases
 
         content = BeautifulSoup(response.text, "html.parser")
@@ -57,7 +129,7 @@ def sf_feed(shared_state, start_time, request_from):
                         imdb_id = None  # imdb info is missing here
 
                         payload = urlsafe_b64encode(
-                            f"{title}|{source}|{mb}|{password}|{imdb_id}".encode("utf-8")).decode("utf-8")
+                            f"{title}|{source}|{mirror}|{mb}|{password}|{imdb_id}".encode("utf-8")).decode("utf-8")
                         link = f"{shared_state.values['internal_address']}/download/?payload={payload}"
                     except:
                         continue
@@ -75,9 +147,11 @@ def sf_feed(shared_state, start_time, request_from):
 
                     releases.append({
                         "details": {
-                            "title": f"[SF] {title}",
+                            "title": title,
+                            "hostname": hostname.lower(),
                             "imdb_id": imdb_id,
                             "link": link,
+                            "mirror": mirror,
                             "size": size,
                             "date": published,
                             "source": source,
@@ -86,22 +160,24 @@ def sf_feed(shared_state, start_time, request_from):
                     })
 
             except Exception as e:
-                info(f"Error parsing SF feed: {e}")
+                info(f"Error parsing {hostname.upper()} feed: {e}")
 
     elapsed_time = time.time() - start_time
-    debug(f"Time taken: {elapsed_time:.2f} seconds (sf)")
+    debug(f"Time taken: {elapsed_time:.2f} seconds ({hostname.lower()})")
 
     return releases
 
 
 def extract_season_episode(search_string):
-    match = re.search(r'(.*?)(S\d{1,3})(?:E(\d{1,3}))?', search_string, re.IGNORECASE)
-    if match:
-        title = match.group(1).strip()
-        season = int(match.group(2)[1:])
-        episode = int(match.group(3)) if match.group(3) else None
-        return title, season, episode
-    return search_string, None, None
+    try:
+        match = re.search(r'(.*?)(S\d{1,3})(?:E(\d{1,3}))?', search_string, re.IGNORECASE)
+        if match:
+            season = int(match.group(2)[1:])
+            episode = int(match.group(3)) if match.group(3) else None
+            return season, episode
+    except Exception as e:
+        debug(f"Error extracting season / episode from {search_string}: {e}")
+    return None, None
 
 
 def extract_size(text):
@@ -114,15 +190,20 @@ def extract_size(text):
         raise ValueError(f"Invalid size format: {text}")
 
 
-def sf_search(shared_state, start_time, request_from, search_string):
+def sf_search(shared_state, start_time, request_from, search_string, mirror=None):
     releases = []
-    sf = shared_state.values["config"]("Hostnames").get("sf")
+    sf = shared_state.values["config"]("Hostnames").get(hostname.lower())
     password = sf
 
-    title, season, episode = extract_season_episode(search_string)
+    season, episode = extract_season_episode(search_string)
 
     if "Radarr" in request_from:
-        debug(f"Skipped Radarr search (sf)")
+        debug(f'Skipping Radarr search on "{hostname.upper()}" (unsupported media type at hostname)!')
+        return releases
+
+    if mirror and mirror not in supported_mirrors:
+        debug(f'Mirror "{mirror}" not supported by "{hostname.upper()}". Supported mirrors: {supported_mirrors}.'
+              ' Skipping search!')
         return releases
 
     if re.match(r'^tt\d{7,8}$', search_string):
@@ -144,7 +225,7 @@ def sf_search(shared_state, start_time, request_from, search_string):
         response = requests.get(url, headers, timeout=10)
         feed = response.json()
     except Exception as e:
-        info(f"Error loading SF search: {e}")
+        info(f"Error loading {hostname.upper()} search: {e}")
         return releases
 
     results = feed['result']
@@ -161,7 +242,7 @@ def sf_search(shared_state, start_time, request_from, search_string):
                         season = "ALL"
 
                     series_id = result["url_id"]
-                    threshold = 30
+                    threshold = 15  # this should cut down duplicates in case Sonarr is searching variants of a title
                     context = "recents_sf"
                     recently_searched = shared_state.get_recently_searched(shared_state, context, threshold)
                     if series_id in recently_searched:
@@ -196,15 +277,25 @@ def sf_search(shared_state, start_time, request_from, search_string):
                 for item in items:
                     try:
                         details = item.parent.parent.parent
-                        name = details.find("small").text.strip()
+                        title = details.find("small").text.strip()
 
-                        if not shared_state.search_string_in_sanitized_title(search_string, name):
+                        if not shared_state.search_string_in_sanitized_title(search_string, title):
                             continue
 
                         size_string = item.find("span", {"class": "morespec"}).text.split("|")[1].strip()
                         size_item = extract_size(size_string)
-                        source = f'https://{sf}{details.find("a")["href"]}'
+                        mirrors = parse_mirrors(f"https://{sf}", details)
+
+                        if mirror:
+                            if mirror not in mirrors["season"]:
+                                continue
+                            source = mirrors["season"][mirror]
+                            if not source:
+                                info(f"Could not find mirror '{mirror}' for '{title}'")
+                        else:
+                            source = next(iter(mirrors["season"]))
                     except:
+                        debug(f"Could not find link for '{search_string}'")
                         continue
 
                     mb = shared_state.convert_to_mb(size_item)
@@ -212,20 +303,28 @@ def sf_search(shared_state, start_time, request_from, search_string):
                     if episode:
                         mb = 0
                         try:
-                            if not re.search(r'S\d{1,3}E\d{1,3}', name):
-                                name = re.sub(r'(S\d{1,3})', rf'\1E{episode:02d}', name)
+                            if not re.search(r'S\d{1,3}E\d{1,3}', title):
+                                title = re.sub(r'(S\d{1,3})', rf'\1E{episode:02d}', title)
 
-                                item_details = details.find("div", {"class": "list simple"})
-                                details_episodes = item_details.find_all("div", {"class": "row"})
-                                episodes_in_release = 0
+                                # Count episodes
+                                episodes_in_release = len(mirrors["episodes"])
 
-                                for row in details_episodes:
-                                    main_row = row.find_all("div", {"class": "row"})
-                                    links_in_row = row.find_all("a", {"class": "dlb row"})
-                                    if main_row and links_in_row:
-                                        episodes_in_release += 1
-                                        if episodes_in_release == episode:
-                                            source = f'https://{sf}{links_in_row[0]["href"]}'
+                                # Get the correct episode entry (episode numbers are 1-based, list index is 0-based)
+                                episode_data = next((e for e in mirrors["episodes"] if e["number"] == int(episode)),
+                                                    None)
+
+                                if episode_data:
+                                    if mirror:
+                                        if mirror not in episode_data["links"]:
+                                            debug(
+                                                f"Mirror '{mirror}' does not exist for '{title}' episode {episode}'")
+                                        else:
+                                            source = episode_data["links"][mirror]
+
+                                    else:
+                                        source = next(iter(episode_data["links"].values()))
+                                else:
+                                    debug(f"Episode '{episode}' data not found in mirrors for '{title}'")
 
                                 if episodes_in_release:
                                     mb = shared_state.convert_to_mb({
@@ -235,7 +334,7 @@ def sf_search(shared_state, start_time, request_from, search_string):
                         except:
                             continue
 
-                    payload = urlsafe_b64encode(f"{name}|{source}|{mb}|{password}|{imdb_id}".
+                    payload = urlsafe_b64encode(f"{title}|{source}|{mirror}|{mb}|{password}|{imdb_id}".
                                                 encode("utf-8")).decode("utf-8")
                     link = f"{shared_state.values['internal_address']}/download/?payload={payload}"
 
@@ -251,9 +350,11 @@ def sf_search(shared_state, start_time, request_from, search_string):
 
                     releases.append({
                         "details": {
-                            "title": f"[SF] {name}",
+                            "title": title,
+                            "hostname": hostname.lower(),
                             "imdb_id": imdb_id,
                             "link": link,
+                            "mirror": mirror,
                             "size": size,
                             "date": published,
                             "source": f"{series_url}/{season}" if season else series_url
@@ -262,11 +363,11 @@ def sf_search(shared_state, start_time, request_from, search_string):
                     })
 
             except Exception as e:
-                info(f"Error parsing SF search: {e}")
+                info(f"Error parsing {hostname.upper()} search: {e}")
         else:
             debug(f"Search string '{search_string}' does not match result '{result['title']}'")
 
     elapsed_time = time.time() - start_time
-    debug(f"Time taken: {elapsed_time:.2f} seconds (sf)")
+    debug(f"Time taken: {elapsed_time:.2f} seconds ({hostname.lower()})")
 
     return releases


### PR DESCRIPTION
If you prefer to only get releases for a specific mirror, add the mirror name to the API path in the advanced indexer settings.
* Example: `/api/dropbox/` results will only return releases where `dropbox` is explicitly mentioned in link.
  <img width="495" alt="image" src="https://github.com/user-attachments/assets/acbced9f-82e3-407a-baf5-ba4c7fe51d12" />
* This means that if a mirror is not available at a hostname, the release will be ignored.