### PR TITLE
Fix incorrect iteration over mirrors in source fetching

### DIFF
--- a/quasarr/downloads/sources/sf.py
+++ b/quasarr/downloads/sources/sf.py
@@ -95,7 +95,7 @@ def get_sf_download_links(shared_state, url, mirror, title):
                         if not release_url:
                             info(f"Could not find mirror '{mirror}' for '{title}'")
                     else:
-                        release_url = next(iter(mirrors["season"]))
+                        release_url = next(iter(mirrors["season"].values()))
 
                     real_url = resolve_sf_redirect(release_url, shared_state.values["user_agent"])
                     return real_url

--- a/quasarr/providers/version.py
+++ b/quasarr/providers/version.py
@@ -6,7 +6,7 @@ import re
 
 
 def get_version():
-    return "1.3.3"
+    return "1.3.4"
 
 
 def create_version_file():


### PR DESCRIPTION
Corrected the iteration logic for mirrors to use `.values()` when accessing season entries. This ensures the appropriate release URL is retrieved and resolves potential issues with source fetching.