### PR TITLE
Improve failed download handling

### DIFF
--- a/quasarr/api/arr/__init__.py
+++ b/quasarr/api/arr/__init__.py
@@ -63,15 +63,20 @@ def setup_arr_routes(app):
             password = root.find(".//file").attrib.get("password")
             imdb_id = root.find(".//file").attrib.get("imdb_id")
 
-            info(f"Attempting download for {title}")
+            info(f'Attempting download for "{title}"')
             request_from = request.headers.get('User-Agent')
-            package_id = download(shared_state, request_from, title, url, mirror, size_mb, password, imdb_id)
+            downloaded = download(shared_state, request_from, title, url, mirror, size_mb, password, imdb_id)
+            try:
+                success = downloaded["success"]
+                package_id = downloaded["package_id"]
 
-            if package_id:
-                info(f"{title} added successfully!")
+                if success:
+                    info(f'"{title}" added successfully!')
+                else:
+                    info(f'"{title}" added unsuccessfully! See log for details.')
                 nzo_ids.append(package_id)
-            else:
-                info(f"{title} could not be added!")
+            except KeyError:
+                info(f'Failed to download "{title}" - no package_id returned')
 
         return {
             "status": True,

--- a/quasarr/api/arr/__init__.py
+++ b/quasarr/api/arr/__init__.py
@@ -200,7 +200,15 @@ def setup_arr_routes(app):
                                                       )
 
                     elif mode == 'search':
-                        debug(f'Search in Anime-Order is not supported. Ignoring request: {dict(request.query)}')
+                        # supported params: q
+                        search_param = getattr(request.query, 'q', '')
+                        if search_param:
+                            releases = get_search_results(shared_state, request_from,
+                                                          search_string=search_param,
+                                                          mirror=mirror
+                                                          )
+                        else:
+                            debug(f'No search parameter provided. Ignoring request: {dict(request.query)}')
 
                     elif mode == 'tvsearch':
                         # supported params: q, imdbid, season and ep

--- a/quasarr/downloads/packages/__init__.py
+++ b/quasarr/downloads/packages/__init__.py
@@ -121,6 +121,11 @@ def get_packages(shared_state):
             package_id = package[0]
 
             data = json.loads(package[1])
+            try:
+                if type(data) is str:
+                    data = json.loads(data)
+            except json.JSONDecodeError:
+                pass
             details = {
                 "name": data["title"],
                 "bytesLoaded": 0,
@@ -131,7 +136,7 @@ def get_packages(shared_state):
                 "details": details,
                 "location": "history",
                 "type": "failed",
-                "error": "Too many failed attempts by SponsorsHelper",
+                "error": data["error"],
                 "comment": package_id,
                 "uuid": package_id
             })

--- a/quasarr/providers/version.py
+++ b/quasarr/providers/version.py
@@ -8,7 +8,7 @@ import requests
 
 
 def get_version():
-    return "1.5.8"
+    return "1.5.9"
 
 
 def get_latest_version():


### PR DESCRIPTION
In #109  we noticed that failing downloads for offline releases too early skips the failed download handling by Radarr/Sonarr.

Now releases that have 0 links found will still be added to the queue but marked as failed.
Radarr/Sonarr will then automatically blocklist these failed downloads.