### PR TITLE
Add new source: N4

### DIFF
--- a/quasarr/downloads/__init__.py
+++ b/quasarr/downloads/__init__.py
@@ -14,7 +14,7 @@ from quasarr.downloads.sources.dd import get_dd_download_links
 from quasarr.downloads.sources.dt import get_dt_download_links
 from quasarr.downloads.sources.dw import get_dw_download_links
 from quasarr.downloads.sources.mb import get_mb_download_links
-from quasarr.downloads.sources.n4 import get_n4_download_links
+from quasarr.downloads.sources.nk import get_nk_download_links
 from quasarr.downloads.sources.nx import get_nx_download_links
 from quasarr.downloads.sources.sf import get_sf_download_links, resolve_sf_redirect
 from quasarr.downloads.sources.sl import get_sl_download_links
@@ -203,7 +203,7 @@ def download(shared_state, request_from, title, url, mirror, size_mb, password, 
         'DT': config.get("dt"),
         'DW': config.get("dw"),
         'MB': config.get("mb"),
-        'N4': config.get("n4"),
+        'NK': config.get("nk"),
         'NX': config.get("nx"),
         'SF': config.get("sf"),
         'SL': config.get("sl"),
@@ -217,7 +217,7 @@ def download(shared_state, request_from, title, url, mirror, size_mb, password, 
         (flags['DT'], lambda *a: handle_unprotected(*a, func=get_dt_download_links, label='DT')),
         (flags['DW'], lambda *a: handle_protected(*a, func=get_dw_download_links, label='DW')),
         (flags['MB'], lambda *a: handle_protected(*a, func=get_mb_download_links, label='MB')),
-        (flags['N4'], lambda *a: handle_protected(*a, func=get_n4_download_links, label='N4')),
+        (flags['NK'], lambda *a: handle_protected(*a, func=get_nk_download_links, label='NK')),
         (flags['NX'], lambda *a: handle_unprotected(*a, func=get_nx_download_links, label='NX')),
         (flags['SF'], handle_sf),
         (flags['SL'], handle_sl),

--- a/quasarr/downloads/sources/nk.py
+++ b/quasarr/downloads/sources/nk.py
@@ -10,9 +10,11 @@ from bs4 import BeautifulSoup
 from quasarr.providers.log import info, debug
 from urllib.parse import urlparse, urljoin
 
+hostname = "nk"
 
-def get_n4_download_links(shared_state, url, mirror, title):
-    n4 = shared_state.values["config"]("Hostnames").get("n4")
+
+def get_nk_download_links(shared_state, url, mirror, title):
+    host = shared_state.values["config"]("Hostnames").get(hostname)
     headers = {
         'User-Agent': shared_state.values["user_agent"],
     }
@@ -23,7 +25,7 @@ def get_n4_download_links(shared_state, url, mirror, title):
         resp = session.get(url, headers=headers, timeout=20)
         soup = BeautifulSoup(resp.text, 'html.parser')
     except Exception as e:
-        info(f"N4: could not fetch release page for {title}: {e}")
+        info(f"{hostname}: could not fetch release page for {title}: {e}")
         return False
 
     # download links are provided as anchors with class 'dl-button'
@@ -34,12 +36,12 @@ def get_n4_download_links(shared_state, url, mirror, title):
         href = a.get('href', '').strip()
         hoster = href.split('/')[3].lower()
         if not href.lower().startswith(('http://', 'https://')):
-            href  = 'https://' + n4 + href
+            href  = 'https://' + host + href
 
         try:
             href = requests.head(href, headers=headers, allow_redirects=True, timeout=20).url
         except Exception as e:
-            info(f"N4: could not resolve download link for {title}: {e}")
+            info(f"{hostname}: could not resolve download link for {title}: {e}")
             continue
 
         if hoster == 'ddl.to':
@@ -48,6 +50,6 @@ def get_n4_download_links(shared_state, url, mirror, title):
         candidates.append([href, hoster])
 
     if not candidates:
-        info(f"No external download links found on N4 page for {title}")
+        info(f"No external download links found on {hostname} page for {title}")
 
     return candidates

--- a/quasarr/search/__init__.py
+++ b/quasarr/search/__init__.py
@@ -13,7 +13,7 @@ from quasarr.search.sources.dt import dt_feed, dt_search
 from quasarr.search.sources.dw import dw_feed, dw_search
 from quasarr.search.sources.fx import fx_feed, fx_search
 from quasarr.search.sources.mb import mb_feed, mb_search
-from quasarr.search.sources.n4 import n4_search
+from quasarr.search.sources.nk import nk_feed, nk_search
 from quasarr.search.sources.nx import nx_feed, nx_search
 from quasarr.search.sources.sf import sf_feed, sf_search
 from quasarr.search.sources.sl import sl_feed, sl_search
@@ -35,7 +35,7 @@ def get_search_results(shared_state, request_from, imdb_id="", search_phrase="",
     dw = shared_state.values["config"]("Hostnames").get("dw")
     fx = shared_state.values["config"]("Hostnames").get("fx")
     mb = shared_state.values["config"]("Hostnames").get("mb")
-    n4 = shared_state.values["config"]("Hostnames").get("n4")
+    nk = shared_state.values["config"]("Hostnames").get("nk")
     nx = shared_state.values["config"]("Hostnames").get("nx")
     sf = shared_state.values["config"]("Hostnames").get("sf")
     sl = shared_state.values["config"]("Hostnames").get("sl")
@@ -54,7 +54,7 @@ def get_search_results(shared_state, request_from, imdb_id="", search_phrase="",
         (dw, dw_search),
         (fx, fx_search),
         (mb, mb_search),
-        (n4, n4_search),
+        (nk, nk_search),
         (nx, nx_search),
         (sf, sf_search),
         (sl, sl_search),
@@ -79,6 +79,7 @@ def get_search_results(shared_state, request_from, imdb_id="", search_phrase="",
         (dw, dw_feed),
         (fx, fx_feed),
         (mb, mb_feed),
+        (nk, nk_feed),
         (nx, nx_feed),
         (sf, sf_feed),
         (sl, sl_feed),

--- a/quasarr/storage/config.py
+++ b/quasarr/storage/config.py
@@ -33,7 +33,7 @@ class Config(object):
             ("dw", "secret", ""),
             ("fx", "secret", ""),
             ("mb", "secret", ""),
-            ("n4", "secret", ""),
+            ("nk", "secret", ""),
             ("nx", "secret", ""),
             ("sf", "secret", ""),
             ("sl", "secret", ""),


### PR DESCRIPTION
Erstmal nur Suche, bei Interesse kann ich den Feed auch hinzufügen.

Für die Suche wird die IMDB id zum lokalisierten Name aufgelöst.

Die eigentlichen Releases haben teilweise deutschen Namen die von Radarr/Sonarr abgelehnt werden, damit das möglichst gut funktioniert wird der Releasename priorisiert, falls der nicht akzeptiert würde werden mehrere Kombinationen probiert - hier ist bestimmt noch Luft nach oben, aber in meinen Tests (mehrere Filme und Serien) hab ich so immer einem Match bekommen.

Bei Serien stimmt leider die Größe nicht, da die Quelle für Serien die Größe nur pro EP angibt - aktuell sieht man dann in Sonarr die Größe einer Folge für die ganze Serie - ich bin nicht sicher ob ich die Größe in dem Fall lieber auf 0 setzen sollte oder ob ichs probieren sollte die Größe anhand der Beschreibung zu schätzen - für die exakte Größe bei Serien seh ich hier jedenfalls keine Option.