### PR TITLE
Improved archive detection

### DIFF
--- a/quasarr/providers/myjd_api.py
+++ b/quasarr/providers/myjd_api.py
@@ -400,6 +400,29 @@ class Downloads:
         return resp
 
 
+class Extraction:
+    """
+    Class that represents the extraction details of a Device
+    """
+
+    def __init__(self, device):
+        self.device = device
+        self.url = "/extraction"
+
+    def get_archive_info(self, link_ids=[], package_ids=[]):
+        """
+        Get ArchiveStatus for links and/or packages.
+
+        :param package_ids: Package UUID's.
+        :type: list of strings.
+        :param link_ids: link UUID's.
+        :type: list of strings
+        """
+        params = [link_ids, package_ids]
+        resp = self.device.action(self.url + "/getArchiveInfo", params)
+        return resp
+
+
 class Jddevice:
     """
     Class that represents a JDownloader device and it's functions
@@ -418,6 +441,7 @@ class Jddevice:
         self.config = Config(self)
         self.linkgrabber = Linkgrabber(self)
         self.downloads = Downloads(self)
+        self.extraction = Extraction(self)
         self.downloadcontroller = DownloadController(self)
         self.update = Update(self)
         self.__direct_connection_info = None

--- a/quasarr/providers/version.py
+++ b/quasarr/providers/version.py
@@ -8,7 +8,7 @@ import requests
 
 
 def get_version():
-    return "1.20.2"
+    return "1.20.3"
 
 
 def get_latest_version():


### PR DESCRIPTION
Currently there are situations where the download API from myJD does not properly inform when archives have not finished extraction, sometimes causing *arr software to import files too soon and causing broken files.

I added an additional call to the Extraction API which will enrich the processing by letting Quasarr know which packages are actually archives and thus should report "Extraction OK" before they can be considered finished, even though myJD API might report them as "finished" early.