### PR TITLE
Added cached archive detection per link

### DIFF
--- a/quasarr/providers/version.py
+++ b/quasarr/providers/version.py
@@ -8,7 +8,7 @@ import requests
 
 
 def get_version():
-    return "1.26.4"
+    return "1.26.5"
 
 
 def get_latest_version():


### PR DESCRIPTION
Archive detection per package has issues on packages that included both archives and non-archive.
This PR changes archive detection to be per link instead.

> [!NOTE]
> New archive detection is per link, however each link needs to be queried individually because of myJD API design:
>
> *The extraction API does allow querying multiple links or a packages at once, however the result does not provide any safe identifiers that can be used to match the results to any specific link. Even worse is that non-archives are omitted from the result, so enumeration of the result also does not work.*
>
> To reduce network overhead as much as possible I added a cache mechanic, so archive info per link is only queried once and then carried over until the link is removed from jDownloader.