### PR TITLE
Fix Radarr indexer temporarily unavailable

### DIFF
--- a/quasarr/api/arr/__init__.py
+++ b/quasarr/api/arr/__init__.py
@@ -327,7 +327,7 @@ def setup_arr_routes(app):
                             else:
                                 info(
                                     f'Ignoring search request from {request_from} - only imdbid searches are supported')
-                                releases = [{}]  # sonarr expects this but we will not support non-imdbid searches
+                                releases = []  # sonarr expects this but we will not support non-imdbid searches
 
                     items = ""
                     for release in releases:
@@ -353,7 +353,7 @@ def setup_arr_routes(app):
                             <enclosure url="{release.get("link", "")}" length="{release.get("size", 0)}" type="application/x-nzb" />
                         </item>'''
 
-                    is_feed_request = not getattr(request.query, 'imdbid', '')
+                    is_feed_request = not getattr(request.query, 'imdbid', '') and not getattr(request.query, 'q', '')
                     if is_feed_request and not items:
                         items = f'''
                         <item>

--- a/quasarr/providers/version.py
+++ b/quasarr/providers/version.py
@@ -8,7 +8,7 @@ import requests
 
 
 def get_version():
-    return "1.28.0"
+    return "1.28.1"
 
 
 def get_latest_version():


### PR DESCRIPTION
When searches in Radarr find no results Radarr tries a second search without imdb ID, which then causes issues.
I did not encounter these issues until recently so it might be tied to a recent Radarr update.

<img width="1146" height="432" alt="image" src="https://github.com/user-attachments/assets/8e7330f8-71c8-4ad4-8e42-c1aad08bd666" />

The fix is in two parts, first just clearing the results array instead of setting it to [{}]. I could not find any reason to include {} in the array for Sonarr, it works just fine with or without it, while [{}] caused issues with Radarr.

The second change was to actually check for imdbid and q on the query parameters to detect whether the request is a feed or search, checking for q then covers the second search radarr does without imdb ID.

Tested with Radarr & Sonarr, with results, without results & feed.