### PR TITLE
Added alternative cached IMDB source. Added year to searches for HE and NK

### DIFF
--- a/quasarr/providers/version.py
+++ b/quasarr/providers/version.py
@@ -8,7 +8,7 @@ import requests
 
 
 def get_version():
-    return "2.2.0"
+    return "2.3.0"
 
 
 def get_latest_version():

--- a/quasarr/search/sources/he.py
+++ b/quasarr/search/sources/he.py
@@ -12,7 +12,7 @@ import requests
 from bs4 import BeautifulSoup
 
 from quasarr.providers.hostname_issues import mark_hostname_issue, clear_hostname_issue
-from quasarr.providers.imdb_metadata import get_localized_title
+from quasarr.providers.imdb_metadata import get_localized_title, get_year
 from quasarr.providers.log import info, debug
 
 hostname = "he"
@@ -84,6 +84,9 @@ def he_search(shared_state, start_time, request_from, search_string="", mirror=N
             if not local_title:
                 info(f"{hostname}: no title for IMDb {imdb_id}")
                 return releases
+            year = get_year(imdb_id)
+            if year:
+                local_title += f" {year}"
             source_search = local_title
         else:
             return releases

--- a/quasarr/search/sources/nk.py
+++ b/quasarr/search/sources/nk.py
@@ -13,7 +13,7 @@ import requests
 from bs4 import BeautifulSoup
 
 from quasarr.providers.hostname_issues import mark_hostname_issue, clear_hostname_issue
-from quasarr.providers.imdb_metadata import get_localized_title
+from quasarr.providers.imdb_metadata import get_localized_title, get_year
 from quasarr.providers.log import info, debug
 
 hostname = "nk"
@@ -75,6 +75,9 @@ def nk_search(shared_state, start_time, request_from, search_string="", mirror=N
             if not local_title:
                 info(f"{hostname}: no title for IMDb {imdb_id}")
                 return releases
+            year = get_year(imdb_id)
+            if year:
+                local_title += f" {year}"
             source_search = local_title
         else:
             return releases


### PR DESCRIPTION
I added a ttl to the cached entries to make sure we don't cache wrong/outdated data forever.

Normal operation will mean the data is cached for a month per title.
If anything goes wrong (no poster found, no localized title found) the cache ttl is reduced to one day  so it will try to refresh earlier.