### PR TITLE
Refactor SponsorsHelper API

### DIFF
--- a/.github/workflows/Release.yml
+++ b/.github/workflows/Release.yml
@@ -181,6 +181,14 @@ jobs:
         uses: metcalfc/changelog-generator@v4.6.2
         with:
           myToken: ${{ secrets.GITHUB_TOKEN }}
+      - name: Add PR Body to Changelog
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          PR_BODY=$(gh pr list --search "${{ github.sha }}" --state merged --json body --jq '.[0].body // empty')
+          if [ -n "$PR_BODY" ]; then
+            echo -e "\n$PR_BODY" >> .github/Changelog.md
+          fi
       - name: Append changelog
         run: echo -e "\n${{ steps.changelog.outputs.changelog }}" >> .github/Changelog.md
       - name: Create Release

--- a/quasarr/providers/version.py
+++ b/quasarr/providers/version.py
@@ -8,7 +8,7 @@ import requests
 
 
 def get_version():
-    return "2.3.2"
+    return "2.3.3"
 
 
 def get_latest_version():


### PR DESCRIPTION
⚠️ BREAKING CHANGE ALERT ⚠️
🛑 STOP & READ: This release introduces API endpoint changes that are not backward compatible.
🔄 ACTION REQUIRED: You MUST update the Sponsors Helper to the latest version simultaneously with this deployment.

- Rename endpoints: `to_download` -> `download`, `to_replace` -> `disable`, `to_failed` -> `fail`
- Update `to_decrypt` to skip disabled packages
- Replace `to_replace` logic with package disabling
- Bump version to 2.3.3