### PR TITLE
Add Discord notification for disabled packages

### DIFF
--- a/quasarr/api/sponsors_helper/__init__.py
+++ b/quasarr/api/sponsors_helper/__init__.py
@@ -121,6 +121,8 @@ def setup_sponsors_helper_routes(app):
 
             StatsHelper(shared_state).increment_captcha_decryptions_automatic()
 
+            send_discord_message(shared_state, title=title, case="disabled")
+
             return f"Package {title} disabled"
 
         except Exception as e:

--- a/quasarr/providers/notifications.py
+++ b/quasarr/providers/notifications.py
@@ -53,7 +53,10 @@ def send_discord_message(shared_state, title, case, imdb_id=None, details=None, 
         description = 'CAPTCHA solved by SponsorsHelper!'
         fields = None
     elif case == "failed":
-        description = 'SponsorsHelper failed to solve the CAPTCHA! Package marked es failed.'
+        description = 'SponsorsHelper failed to solve the CAPTCHA! Package marked as failed for deletion.'
+        fields = None
+    elif case == "disabled":
+        description = 'SponsorsHelper failed to solve the CAPTCHA! Please solve it manually to proceed.'
         fields = None
     elif case == "captcha":
         description = 'Download will proceed, once the CAPTCHA has been solved.'
@@ -112,7 +115,7 @@ def send_discord_message(shared_state, title, case, imdb_id=None, details=None, 
         }
 
     # Apply silent mode: suppress notifications for all cases except 'deleted'
-    if silent and case not in ["failed", "quasarr_update"]:
+    if silent and case not in ["failed", "quasarr_update", "disabled"]:
         data['flags'] = SUPPRESS_NOTIFICATIONS
 
     response = requests.post(shared_state.values["discord"], data=json.dumps(data),

--- a/quasarr/providers/version.py
+++ b/quasarr/providers/version.py
@@ -8,7 +8,7 @@ import requests
 
 
 def get_version():
-    return "2.4.0"
+    return "2.4.1"
 
 
 def get_latest_version():


### PR DESCRIPTION
- Send Discord message when SponsorsHelper disables a package
- Add "disabled" case to notifications and exclude it from silent mode suppression