### PR TITLE
Switch Docker base image to python:3.12-slim-bookworm

### DIFF
--- a/.github/Changelog.md
+++ b/.github/Changelog.md
@@ -1,5 +1,5 @@
 ### Install / Update:
 
-`uv tool install quasarr`
+`uv tool upgrade quasarr`
 
 ### Changelog:

--- a/README.md
+++ b/README.md
@@ -187,13 +187,14 @@ docker run -d \
 
 # Manual setup
 
-Use this only in case you can't run the docker image.
+> Use this only in case you can't run the docker image.
+
+> ⚠️ Requires Python 3.12 (or later) and [uv](https://docs.astral.sh/uv/#installation)!
 
 `uv tool install quasarr`
 
-* Requires Python 3.12 or later
-
 ```
+quasarr
   --port=8080
   --discord=https://discord.com/api/webhooks/1234567890/ABCDEFGHIJKLMN
   --external_address=https://foo.bar/

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,6 +1,6 @@
 FROM ghcr.io/astral-sh/uv:latest AS uv
 
-FROM alpine:latest
+FROM python:3.12-slim-bookworm
 MAINTAINER rix1337
 
 LABEL org.opencontainers.image.description="Quasarr connects JDownloader with Radarr, Sonarr and LazyLibrarian. It also decrypts links protected by CAPTCHAs."
@@ -9,8 +9,6 @@ LABEL org.opencontainers.image.description="Quasarr connects JDownloader with Ra
 ARG PACKAGE_NAME=quasarr
 
 COPY --from=uv /uv /usr/local/bin/uv
-
-RUN apk add --no-cache python3
 
 # install local package
 COPY dist/*.whl /tmp/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ dependencies = [
     "requests>=2.32.5",
 ]
 authors = [
-    { name = "rix1337", email = "" }
+    { name = "rix1337", email = "rix1337@users.noreply.github.com" }
 ]
 classifiers = [
     "Programming Language :: Python :: 3",

--- a/quasarr/providers/version.py
+++ b/quasarr/providers/version.py
@@ -5,7 +5,7 @@
 import re
 import sys
 
-__version__ = "2.4.3"
+__version__ = "2.4.4"
 
 
 def get_version():


### PR DESCRIPTION
Enjoy even faster release builds and a smaller, modern base image.