### PR TITLE
Optimize CI workflows and switch to uv publish

### DIFF
--- a/.github/workflows/Beta.yml
+++ b/.github/workflows/Beta.yml
@@ -24,7 +24,6 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v5
         with:
-          # Fixed: Added glob to silence warning since you might not have uv.lock
           enable-cache: true
           cache-dependency-glob: "pyproject.toml"
       - name: Get Version
@@ -35,6 +34,10 @@ jobs:
   build-wheel:
     name: Build Wheel
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+      attestations: write
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-python@v5
@@ -47,6 +50,12 @@ jobs:
           cache-dependency-glob: "pyproject.toml"
       - name: Build wheel
         run: uv build
+
+      - name: Generate artifact attestation
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-path: "dist/*.whl"
+
       - uses: actions/upload-artifact@v4
         with:
           name: wheel
@@ -66,26 +75,26 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: '3.12'
+
       - name: Install uv
         uses: astral-sh/setup-uv@v5
         with:
           enable-cache: true
           cache-dependency-glob: "pyproject.toml"
-      - uses: actions/cache@v4
-        with:
-          path: ~\AppData\Local\pyinstaller
-          key: ${{ runner.os }}-pyinstaller-${{ hashFiles('pyproject.toml') }}
-          restore-keys: ${{ runner.os }}-pyinstaller-
+
       - name: Disable Windows Defender
         shell: powershell
         run: Set-MpPreference -DisableRealtimeMonitoring $true
+
       - name: Install dependencies
         run: |
           uv sync --group build
+
       - name: Build exe
         run: |
           uv run python quasarr/providers/version.py --create-version-file
           uv run pyinstaller --clean --onefile -y --version-file "file_version_info.txt" "Quasarr.py" -n "quasarr-${{ needs.version.outputs.version }}-standalone-win64"
+
       - uses: actions/upload-artifact@v4
         with:
           name: exe-amd64
@@ -162,7 +171,6 @@ jobs:
     runs-on: ubuntu-latest
     needs: [ version, build-docker-amd64, build-docker-arm64 ]
     steps:
-      # Fixed: Added setup-buildx-action to ensure 'imagetools' supports annotations correctly
       - uses: docker/setup-buildx-action@v3
       - uses: docker/login-action@v3
         with:
@@ -171,20 +179,17 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Create and Push Manifests
         run: |
-          # 1. Define source tags
           TAG_AMD64="${{ needs.version.outputs.version }}-beta-amd64"
           TAG_ARM64="${{ needs.version.outputs.version }}-beta-arm64"
-          
-          # Fixed: Use shell variable directly and 'index:' prefix to strictly target the manifest list
           ANNOTATION="index:org.opencontainers.image.description=$DESCRIPTION"
           
-          # 2. Create manifest for GHCR :beta
+          # Manifest for :beta
           docker buildx imagetools create -t ${{ env.GHCR_ENDPOINT }}:beta \
             --annotation "$ANNOTATION" \
             ${{ env.GHCR_ENDPOINT }}:beta-amd64 \
             ${{ env.GHCR_ENDPOINT }}:beta-arm64
 
-          # 3. Create manifest for GHCR :version-beta
+          # Manifest for :version-beta
           docker buildx imagetools create -t ${{ env.GHCR_ENDPOINT }}:${{ needs.version.outputs.version }}-beta \
             --annotation "$ANNOTATION" \
             ${{ env.GHCR_ENDPOINT }}:${TAG_AMD64} \

--- a/.github/workflows/Release.yml
+++ b/.github/workflows/Release.yml
@@ -33,7 +33,6 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v5
         with:
-          # Fixed: Added glob to silence warning
           enable-cache: true
           cache-dependency-glob: "pyproject.toml"
       - name: Get Version
@@ -44,6 +43,10 @@ jobs:
   build-wheel:
     name: Build Wheel
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+      attestations: write
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-python@v5
@@ -56,6 +59,10 @@ jobs:
           cache-dependency-glob: "pyproject.toml"
       - name: Build wheel
         run: uv build
+      - name: Generate artifact attestation
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-path: "dist/*.whl"
       - uses: actions/upload-artifact@v4
         with:
           name: wheel
@@ -75,26 +82,26 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: '3.12'
+
       - name: Install uv
         uses: astral-sh/setup-uv@v5
         with:
           enable-cache: true
           cache-dependency-glob: "pyproject.toml"
-      - uses: actions/cache@v4
-        with:
-          path: ~\AppData\Local\pyinstaller
-          key: ${{ runner.os }}-pyinstaller-${{ hashFiles('pyproject.toml') }}
-          restore-keys: ${{ runner.os }}-pyinstaller-
+
       - name: Disable Windows Defender
         shell: powershell
         run: Set-MpPreference -DisableRealtimeMonitoring $true
+
       - name: Install dependencies
         run: |
           uv sync --group build
+
       - name: Build exe
         run: |
           uv run python quasarr/providers/version.py --create-version-file
           uv run pyinstaller --clean --onefile -y --version-file "file_version_info.txt" "Quasarr.py" -n "quasarr-${{ needs.version.outputs.version }}-standalone-win64"
+
       - uses: actions/upload-artifact@v4
         with:
           name: exe-amd64
@@ -183,7 +190,6 @@ jobs:
     runs-on: ubuntu-latest
     needs: [ version, build-docker-amd64, build-docker-arm64 ]
     steps:
-      # Fixed: Added setup-buildx-action
       - uses: docker/setup-buildx-action@v3
       - uses: docker/login-action@v3
         with:
@@ -196,29 +202,23 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Create and Push Manifests
         run: |
-          # 1. Define source tags
           TAG_AMD64="${{ needs.version.outputs.version }}-amd64"
           TAG_ARM64="${{ needs.version.outputs.version }}-arm64"
-          # Fixed: Added index: prefix and using shell variable
           ANNOTATION="index:org.opencontainers.image.description=$DESCRIPTION"
           
-          # 2. Create manifest for DockerHub :latest
           docker buildx imagetools create -t ${{ env.ENDPOINT }}:latest \
             ${{ env.ENDPOINT }}:latest-amd64 \
             ${{ env.ENDPOINT }}:latest-arm64
 
-          # 3. Create manifest for DockerHub :version
           docker buildx imagetools create -t ${{ env.ENDPOINT }}:${{ needs.version.outputs.version }} \
             ${{ env.ENDPOINT }}:${TAG_AMD64} \
             ${{ env.ENDPOINT }}:${TAG_ARM64}
 
-          # 4. Create manifest for GHCR :latest
           docker buildx imagetools create -t ${{ env.GHCR_ENDPOINT }}:latest \
             --annotation "$ANNOTATION" \
             ${{ env.GHCR_ENDPOINT }}:latest-amd64 \
             ${{ env.GHCR_ENDPOINT }}:latest-arm64
 
-          # 5. Create manifest for GHCR :version
           docker buildx imagetools create -t ${{ env.GHCR_ENDPOINT }}:${{ needs.version.outputs.version }} \
             --annotation "$ANNOTATION" \
             ${{ env.GHCR_ENDPOINT }}:${TAG_AMD64} \
@@ -234,6 +234,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
+
       - uses: actions/download-artifact@v4
         with:
           name: wheel
@@ -242,6 +243,14 @@ jobs:
         with:
           name: exe-amd64
           path: ./exe-amd64
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+
+      - name: Publish to PyPI
+        if: ${{ !inputs.skip_pypi }}
+        run: uv publish ./wheel/* --token ${{ secrets.PYPI_TOKEN }}
+
       - name: Generate changelog
         id: changelog
         uses: metcalfc/changelog-generator@v4.6.2
@@ -257,6 +266,7 @@ jobs:
           fi
       - name: Append changelog
         run: echo -e "\n${{ steps.changelog.outputs.changelog }}" >> .github/Changelog.md
+
       - name: Create Release
         uses: ncipollo/release-action@v1
         with:
@@ -264,9 +274,3 @@ jobs:
           artifactErrorsFailBuild: true
           bodyFile: ".github/Changelog.md"
           tag: v.${{ needs.version.outputs.version }}
-      - name: Install uv
-        uses: astral-sh/setup-uv@v5
-      - name: Upload to PyPI
-        if: ${{ !inputs.skip_pypi }}
-        run: |
-          uv run --with twine --with packaging python -m twine upload ./wheel/* -u __token__ -p ${{ secrets.PYPI_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -4,8 +4,8 @@
 *.pyc
 *.bak
 
-# Build Tools
-venv
+# Virtual Environment by uv
+uv.lock
 .venv
 
 # PyCharm

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -12,7 +12,10 @@ COPY --from=uv /uv /usr/local/bin/uv
 
 # install local package
 COPY dist/*.whl /tmp/
-RUN uv tool install /tmp/*.whl --force && rm /tmp/*.whl
+
+# Updated: Added cache mount for uv to speed up installation
+RUN --mount=type=cache,target=/root/.cache/uv \
+    uv tool install /tmp/*.whl --force && rm /tmp/*.whl
 
 # Ensure the binary is in the PATH
 ENV PATH="/root/.local/bin:$PATH"

--- a/quasarr/providers/shared_state.py
+++ b/quasarr/providers/shared_state.py
@@ -7,9 +7,10 @@ import os
 import re
 import time
 import traceback
-import unicodedata
 from datetime import datetime, timedelta, date
 from urllib import parse
+
+import unicodedata
 
 import quasarr
 from quasarr.providers.log import info, debug

--- a/quasarr/providers/version.py
+++ b/quasarr/providers/version.py
@@ -5,7 +5,7 @@
 import re
 import sys
 
-__version__ = "2.4.5"
+__version__ = "2.4.6"
 
 
 def get_version():


### PR DESCRIPTION
- Add artifact attestation for wheel builds in Beta and Release workflows
- Replace Twine with `uv publish` for PyPI uploads
- Enable `uv` caching in Dockerfile to speed up builds
- Remove manual PyInstaller caching from Windows build steps
- Update .gitignore for `uv` environment files
- Reorder imports in shared_state.py