### PR TITLE
Fix #304 - Replace dynamic imports with static imports for download sources

### DIFF
--- a/quasarr/constants/__init__.py
+++ b/quasarr/constants/__init__.py
@@ -36,12 +36,6 @@ HOSTNAMES = [
 # These hostnames require credentials to be used
 HOSTNAMES_REQUIRING_LOGIN = ["al", "dd", "dj", "dl", "nx", "sj"]
 
-# These hostnames support not only feed and imdb searches, but also search phrases
-HOSTNAMES_SUPPORTING_SEARCH_PHRASE = ["by", "dl", "dt", "nx", "sl", "wd"]
-
-# These hostnames have custom download implementation / getter, right now only FX doesn't
-HOSTNAMES_WITH_CUSTOM_DOWNLOAD_HANDLER = [h for h in HOSTNAMES if h != "fx"]
-
 # ==============================================================================
 # SEARCH & CATEGORIES
 # ==============================================================================

--- a/quasarr/downloads/__init__.py
+++ b/quasarr/downloads/__init__.py
@@ -3,16 +3,31 @@
 # Project by https://github.com/rix1337
 
 import hashlib
-import importlib
 import json
 
 from quasarr.constants import (
     AUTO_DECRYPT_PATTERNS,
-    HOSTNAMES_WITH_CUSTOM_DOWNLOAD_HANDLER,
     PROTECTED_PATTERNS,
 )
 from quasarr.downloads.linkcrypters.hide import decrypt_links_if_hide
 from quasarr.downloads.packages import get_packages
+from quasarr.downloads.sources.al import get_al_download_links
+from quasarr.downloads.sources.by import get_by_download_links
+from quasarr.downloads.sources.dd import get_dd_download_links
+from quasarr.downloads.sources.dj import get_dj_download_links
+from quasarr.downloads.sources.dl import get_dl_download_links
+from quasarr.downloads.sources.dt import get_dt_download_links
+from quasarr.downloads.sources.dw import get_dw_download_links
+from quasarr.downloads.sources.he import get_he_download_links
+from quasarr.downloads.sources.hs import get_hs_download_links
+from quasarr.downloads.sources.mb import get_mb_download_links
+from quasarr.downloads.sources.nk import get_nk_download_links
+from quasarr.downloads.sources.nx import get_nx_download_links
+from quasarr.downloads.sources.sf import get_sf_download_links
+from quasarr.downloads.sources.sj import get_sj_download_links
+from quasarr.downloads.sources.sl import get_sl_download_links
+from quasarr.downloads.sources.wd import get_wd_download_links
+from quasarr.downloads.sources.wx import get_wx_download_links
 from quasarr.providers.hostname_issues import clear_hostname_issue, mark_hostname_issue
 from quasarr.providers.log import info, warn
 from quasarr.providers.notifications import send_discord_message
@@ -28,18 +43,25 @@ from quasarr.storage.categories import (
 )
 
 # All getters have signature: (shared_state, url, mirrors, title, password)
-_SOURCE_GETTERS = {}
-
-for source in HOSTNAMES_WITH_CUSTOM_DOWNLOAD_HANDLER:
-    try:
-        module = importlib.import_module(f"quasarr.downloads.sources.{source}")
-        getter_func = getattr(module, f"get_{source}_download_links", None)
-        if getter_func:
-            _SOURCE_GETTERS[source] = getter_func
-    except ImportError:
-        warn(f"Could not import download source: {source}")
-    except Exception as e:
-        warn(f"Error loading download source {source}: {e}")
+_SOURCE_GETTERS = {
+    "al": get_al_download_links,
+    "by": get_by_download_links,
+    "dd": get_dd_download_links,
+    "dj": get_dj_download_links,
+    "dl": get_dl_download_links,
+    "dt": get_dt_download_links,
+    "dw": get_dw_download_links,
+    "he": get_he_download_links,
+    "hs": get_hs_download_links,
+    "mb": get_mb_download_links,
+    "nk": get_nk_download_links,
+    "nx": get_nx_download_links,
+    "sf": get_sf_download_links,
+    "sj": get_sj_download_links,
+    "sl": get_sl_download_links,
+    "wd": get_wd_download_links,
+    "wx": get_wx_download_links,
+}
 
 
 # =============================================================================

--- a/quasarr/providers/version.py
+++ b/quasarr/providers/version.py
@@ -5,7 +5,7 @@
 import re
 import sys
 
-__version__ = "3.1.1"
+__version__ = "3.1.2"
 
 
 def get_version():

--- a/quasarr/search/__init__.py
+++ b/quasarr/search/__init__.py
@@ -2,15 +2,12 @@
 # Quasarr
 # Project by https://github.com/rix1337
 
-import importlib
 import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from datetime import timezone
 from email.utils import parsedate_to_datetime
 
 from quasarr.constants import (
-    HOSTNAMES,
-    HOSTNAMES_SUPPORTING_SEARCH_PHRASE,
     SEARCH_CAT_BOOKS,
     SEARCH_CAT_MOVIES,
     SEARCH_CAT_MUSIC,
@@ -22,6 +19,24 @@ from quasarr.providers.utils import (
     determine_search_category,
     get_base_search_category_id,
 )
+from quasarr.search.sources.al import al_feed, al_search
+from quasarr.search.sources.by import by_feed, by_search
+from quasarr.search.sources.dd import dd_feed, dd_search
+from quasarr.search.sources.dj import dj_feed, dj_search
+from quasarr.search.sources.dl import dl_feed, dl_search
+from quasarr.search.sources.dt import dt_feed, dt_search
+from quasarr.search.sources.dw import dw_feed, dw_search
+from quasarr.search.sources.fx import fx_feed, fx_search
+from quasarr.search.sources.he import he_feed, he_search
+from quasarr.search.sources.hs import hs_feed, hs_search
+from quasarr.search.sources.mb import mb_feed, mb_search
+from quasarr.search.sources.nk import nk_feed, nk_search
+from quasarr.search.sources.nx import nx_feed, nx_search
+from quasarr.search.sources.sf import sf_feed, sf_search
+from quasarr.search.sources.sj import sj_feed, sj_search
+from quasarr.search.sources.sl import sl_feed, sl_search
+from quasarr.search.sources.wd import wd_feed, wd_search
+from quasarr.search.sources.wx import wx_feed, wx_search
 from quasarr.storage.categories import get_search_category_sources
 
 
@@ -67,34 +82,80 @@ def get_search_results(
     start_time = time.time()
     search_executor = SearchExecutor()
 
-    # Build maps dynamically
-    imdb_map = []
-    phrase_map = []
-    feed_map = []
+    # Config retrieval
+    config = shared_state.values["config"]("Hostnames")
+    al = config.get("al")
+    by = config.get("by")
+    dd = config.get("dd")
+    dl = config.get("dl")
+    dt = config.get("dt")
+    dj = config.get("dj")
+    dw = config.get("dw")
+    fx = config.get("fx")
+    he = config.get("he")
+    hs = config.get("hs")
+    mb = config.get("mb")
+    nk = config.get("nk")
+    nx = config.get("nx")
+    sf = config.get("sf")
+    sj = config.get("sj")
+    sl = config.get("sl")
+    wd = config.get("wd")
+    wx = config.get("wx")
 
-    for source in HOSTNAMES:
-        url = config.get(source)
-        try:
-            module = importlib.import_module(f"quasarr.search.sources.{source}")
+    # Mappings
+    imdb_map = [
+        ("al", al, al_search),
+        ("by", by, by_search),
+        ("dd", dd, dd_search),
+        ("dl", dl, dl_search),
+        ("dt", dt, dt_search),
+        ("dj", dj, dj_search),
+        ("dw", dw, dw_search),
+        ("fx", fx, fx_search),
+        ("he", he, he_search),
+        ("hs", hs, hs_search),
+        ("mb", mb, mb_search),
+        ("nk", nk, nk_search),
+        ("nx", nx, nx_search),
+        ("sf", sf, sf_search),
+        ("sj", sj, sj_search),
+        ("sl", sl, sl_search),
+        ("wd", wd, wd_search),
+        ("wx", wx, wx_search),
+    ]
 
-            search_func = getattr(module, f"{source}_search", None)
-            feed_func = getattr(module, f"{source}_feed", None)
+    phrase_map = [
+        ("by", by, by_search),
+        ("dl", dl, dl_search),
+        ("dt", dt, dt_search),
+        ("nx", nx, nx_search),
+        ("sl", sl, sl_search),
+        ("wd", wd, wd_search),
+    ]
 
-            if search_func:
-                imdb_map.append((source, url, search_func))
-                if source in HOSTNAMES_SUPPORTING_SEARCH_PHRASE:
-                    phrase_map.append((source, url, search_func))
-
-            if feed_func:
-                feed_map.append((source, url, feed_func))
-
-        except ImportError:
-            warn(f"Could not import search source: {source}")
-        except Exception as e:
-            warn(f"Error loading search source {source}: {e}")
+    feed_map = [
+        ("al", al, al_feed),
+        ("by", by, by_feed),
+        ("dd", dd, dd_feed),
+        ("dj", dj, dj_feed),
+        ("dl", dl, dl_feed),
+        ("dt", dt, dt_feed),
+        ("dw", dw, dw_feed),
+        ("fx", fx, fx_feed),
+        ("he", he, he_feed),
+        ("hs", hs, hs_feed),
+        ("mb", mb, mb_feed),
+        ("nk", nk, nk_feed),
+        ("nx", nx, nx_feed),
+        ("sf", sf, sf_feed),
+        ("sj", sj, sj_feed),
+        ("sl", sl, sl_feed),
+        ("wd", wd, wd_feed),
+        ("wx", wx, wx_feed),
+    ]
 
     # Set up searches
-
     if imdb_id:
         stype = f"IMDb-ID <b>{imdb_id}</b>"
     elif search_phrase:


### PR DESCRIPTION
This fixes #304 
Seems the dynamic import logic from 3.0.0 overcomplicates things needlessly.