### PR TITLE
Implement 5-minute timeout for SponsorsHelper status

### DIFF
--- a/cli_tester.py
+++ b/cli_tester.py
@@ -750,6 +750,7 @@ class QuasarrClient:
 
     def enable_sponsor_status(self):
         try:
+            # 1. Enable status
             resp = self.session.put(
                 f"{self.url}/sponsors_helper/api/set_sponsor_status/",
                 params={"apikey": self.api_key},
@@ -757,6 +758,13 @@ class QuasarrClient:
                 timeout=30,
             )
             resp.raise_for_status()
+
+            # 2. Call to_decrypt to set the timestamp
+            self.session.get(
+                f"{self.url}/sponsors_helper/api/to_decrypt/",
+                params={"apikey": self.api_key},
+                timeout=30,
+            )
             return True
         except Exception as e:
             if hasattr(e, "response") and e.response is not None:

--- a/quasarr/providers/html_templates.py
+++ b/quasarr/providers/html_templates.py
@@ -2,8 +2,11 @@
 # Quasarr
 # Project by https://github.com/rix1337
 
+import time
+
 import quasarr.providers.html_images as images
 from quasarr.providers import shared_state
+from quasarr.providers.log import warn
 from quasarr.providers.version import get_version
 
 
@@ -373,6 +376,12 @@ def render_centered_html(inner_content, footer_content=""):
     )
 
     # Determine SponsorsHelper status
+    if shared_state.values.get("helper_active", False):
+        last_seen = shared_state.values.get("helper_last_seen", 0)
+        if time.time() - last_seen > 300:
+            warn("SponsorsHelper last seen more than 5 minutes ago. Deactivating...")
+            shared_state.update("helper_active", False)
+
     if shared_state.values.get("helper_active", False):
         sponsors_helper_status = "SponsorsHelper active"
         sponsors_helper_emoji = "💖"

--- a/quasarr/providers/log.py
+++ b/quasarr/providers/log.py
@@ -94,6 +94,7 @@ _context_replace = {
     "hide": "👻",  # /quasarr/linkcrypters/hide.py
     "packages": "📦",  # /quasarr/api/packages/*
     "providers": "🔌",  # /quasarr/providers/*
+    "html_templates": "🎨",  # /quasarr/providers/html_templates.py
     "imdb_metadata": "🎬",  # /quasarr/providers/imdb_metadata.py
     "jd_cache": "📇",  # /quasarr/providers/jd_cache.py
     "log": "📝",  # /quasarr/providers/log.py

--- a/quasarr/providers/version.py
+++ b/quasarr/providers/version.py
@@ -5,7 +5,7 @@
 import re
 import sys
 
-__version__ = "3.1.4"
+__version__ = "3.1.5"
 
 
 def get_version():


### PR DESCRIPTION
You can now check the web UI footer for sponsors helper status. It will show a broken heart of it hasn't connected to Quasarr in the last 5 minutes.