### PR TITLE
Fixes and improvement for AL

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -15,3 +15,4 @@ services:
       - 'AUTH=form'
       - 'SILENT=True'
       - 'TZ=Europe/Berlin'
+      - 'LOG=INFO'

--- a/quasarr/providers/sessions/al.py
+++ b/quasarr/providers/sessions/al.py
@@ -369,6 +369,7 @@ def fetch_via_requests_session(
     post_data: dict = None,
     timeout: int = 30,
     year: int = None,
+    safe_search: bool = True,
 ):
     """
     - method: "GET" or "POST"
@@ -383,6 +384,9 @@ def fetch_via_requests_session(
 
     if year:
         sess.cookies["filter"] = f'{{"year":{{"from":{year},"to":{year}}}}}'
+
+    # True -> show 18+
+    sess.cookies["safe_search"] = f"{'1' if safe_search else '0'}"
 
     # Execute request
     if method.upper() == "GET":

--- a/quasarr/search/sources/al.py
+++ b/quasarr/search/sources/al.py
@@ -286,6 +286,14 @@ def al_search(
 ):
     releases = []
     host = shared_state.values["config"]("Hostnames").get(hostname)
+    year_filter = shared_state.values["config"]("AL").get("year_filter").lower() in [
+        "true",
+        "1",
+    ]
+    safe_search = shared_state.values["config"]("AL").get("safe_search").lower() in [
+        "true",
+        "1",
+    ]
 
     base_category = get_base_search_category_id(search_category)
 
@@ -314,14 +322,21 @@ def al_search(
 
     encoded_search_string = quote_plus(search_string)
 
+    debug(f"Searching for '{search_string}'")
+
     try:
         url = f"https://www.{host}/search?q={encoded_search_string}"
+        trace(f"Search using URL '{url}'")
+        trace(
+            f"{'Filtering' if year_filter else 'Would filter'} for year {get_year(imdb_id) if imdb_id else None}{'.' if not year_filter else ', but year filter is disabled.'}"
+        )
         r = fetch_via_requests_session(
             shared_state,
             method="GET",
             target_url=url,
             timeout=10,
-            year=get_year(imdb_id) if imdb_id else None,
+            year=get_year(imdb_id) if (imdb_id and year_filter) else None,
+            safe_search=safe_search,
         )
         r.raise_for_status()
     except Exception as e:
@@ -340,7 +355,7 @@ def al_search(
             last_redirect.url, redirect_location
         )  # in case of relative URL
         debug(
-            f"{search_string} redirected to {absolute_redirect_url} instead of search results page"
+            f"'{search_string}' redirected to {absolute_redirect_url} instead of search results page"
         )
 
         try:
@@ -378,6 +393,12 @@ def al_search(
                 if "/anime-series" in href:
                     type_label = "series"
                     break
+                if "/web" in href:
+                    type_label = "series"
+                    break
+                if not safe_search and "/hentai" in href:
+                    type_label = "series"
+                    break
                 if "/anime-movies" in href:
                     type_label = "movie"
                     break
@@ -386,6 +407,8 @@ def al_search(
                 continue
 
             results.append({"url": url, "title": name})
+
+    debug(f"Retrieved {len(results)} result(s)")
 
     for result in results:
         try:

--- a/quasarr/storage/config.py
+++ b/quasarr/storage/config.py
@@ -33,7 +33,12 @@ class Config(object):
         "FlareSolverr": [
             ("url", "str", ""),
         ],
-        "AL": [("user", "secret", ""), ("password", "secret", "")],
+        "AL": [
+            ("user", "secret", ""),
+            ("password", "secret", ""),
+            ("year_filter", "str", "False"),
+            ("safe_search", "str", "False"),
+        ],
         "DD": [("user", "secret", ""), ("password", "secret", "")],
         "DL": [("user", "secret", ""), ("password", "secret", "")],
         "NX": [("user", "secret", ""), ("password", "secret", "")],


### PR DESCRIPTION
- [AL] FIX: Year filter caused wrong search results
  - Disabled by default, can be enabled in config/Quasarr.ini
- [AL] FIX: Allow web and hentai to match as series
  - Before only "anime-series" was allowed as type "series"
  - Added "web" and "hentai" for type_label "series"
- [AL] FEAT: Added config option to disable safe_search
  - Same as the cookie, keep in mind, that it is inverted and therefore "safe_search=True" means "show results for mature content"

---

Primarily wanted to do the fixes as I had issues using the interactive search in Sonarr. After the first two fixes I could at least find more results. As an example IMDb-ID tt0988818 or tt5626028 where it would filter for the year of Season 1.

Maybe you have any further ideas for making the filter better. The issue with above example and AL would be, that there are now too many results for Season 1, but at least there are any for interactive search.

Changing settings in config/Quasarr.ini for AL (safe_search/year_filter) require a fresh session.