### PR TITLE
Improved SponsorsHelper

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -19,13 +19,15 @@ services:
   # Optional (sponsor-only): automatic CAPTCHA solving / decryption helper
   sponsorshelper:
     container_name: 'SponsorsHelper'
-    image: 'ghcr.io/rix1337-sponsors/docker/helper:latest'
+    image: 'ghcr.io/rix1337/sponsors-helper:latest'
     restart: unless-stopped
     depends_on:
       - quasarr
+    volumes:
+      - '/path/to/sponsorshelper-config:/config'
     environment:
-      - 'QUASARR_URL=http://192.168.1.1:8080'
+      - 'QUASARR_URL=http://192.168.0.1:8080'
       - 'QUASARR_API_KEY=your_quasarr_api_key_here'
       - 'APIKEY_2CAPTCHA=your_2captcha_api_key_here'
-      - 'GITHUB_TOKEN=ghp_123.....456789'
+      - 'DEATHBYCAPTCHA_TOKEN=your_deathbycaptcha_token_here'
       - 'FLARESOLVERR_URL=http://10.10.0.1:8191/v1'

--- a/quasarr/providers/version.py
+++ b/quasarr/providers/version.py
@@ -5,7 +5,7 @@
 import re
 import sys
 
-__version__ = "4.1.1"
+__version__ = "4.1.2"
 
 
 def get_version():


### PR DESCRIPTION
# SponsorsHelper now more easy to set up and use

> ⚠️ Existing Users, check the new run command to adapt your config!
> - NO more Github Token to Log in and Download the Image
> - New /config Path mapping to ensure you stay signed in
> - Less information from your GitHub is now shared with the image. More Clean & Secure. 
> - Also available through UNRAID Community Applications

---

## 🔑 GitHub Auth

> ⚠️ Mount `/config` to persistent storage. Otherwise the auth token is lost on container recreation/update.

1. Start your [sponsorship](https://github.com/users/rix1337/sponsorship).
2. Start SponsorsHelper.
3. In container logs, open the GitHub authorization URL shown by SponsorsHelper.
4. Confirm the authorization in browser.
5. Done. SponsorsHelper caches the auth token in `/config/github_oauth_token.json`.

---

## ▶️ Run SponsorsHelper

```bash
docker run -d \
  --name='SponsorsHelper' \
  -v '/path/to/sponsorshelper-config:/config' \
  -e 'QUASARR_URL'='http://192.168.0.1:8080' \
  -e 'QUASARR_API_KEY'='your_quasarr_api_key_here' \
  -e 'APIKEY_2CAPTCHA'='your_2captcha_api_key_here' \
  -e 'FLARESOLVERR_URL'='http://10.10.0.1:8191/v1' \
  ghcr.io/rix1337/sponsors-helper:latest
```

| Parameter              | Description                                                                           |
|------------------------|---------------------------------------------------------------------------------------|
| `QUASARR_URL`          | Local URL of Quasarr (e.g., `http://192.168.0.1:8080`)                                |
| `QUASARR_API_KEY`      | Your Quasarr API key (found in Quasarr web UI under "API Settings")                   |
| `APIKEY_2CAPTCHA`      | [2Captcha](https://2captcha.com/?from=27506687) account API key                       |
| `DEATHBYCAPTCHA_TOKEN` | [DeathByCaptcha](https://deathbycaptcha.com/register?refid=6184288242b) account token |
| `FLARESOLVERR_URL`     | Local URL of [FlareSolverr](https://github.com/FlareSolverr/FlareSolverr)             |

| Volume | Purpose |
|--------|---------|
| `/config` | Persistent SponsorsHelper state (including cached GitHub auth token) |

> - [2Captcha](https://2captcha.com/?from=27506687) is the recommended CAPTCHA solving service.
> - [DeathByCaptcha](https://deathbycaptcha.com/register?refid=6184288242b) can serve as a fallback or work on its own.
> - If you set both `APIKEY_2CAPTCHA` and `DEATHBYCAPTCHA_TOKEN` both services will be used alternately.
