### PR TITLE
Expand DL Jahresthema magazine issues

### DIFF
--- a/quasarr/downloads/sources/dl.py
+++ b/quasarr/downloads/sources/dl.py
@@ -63,6 +63,7 @@ class Source(AbstractDownloadSource):
             if not posts:
                 info(f"Could not find any posts in thread: {url}")
                 return {"links": [], "password": ""}
+            posts = _posts_matching_requested_fragment(posts, url)
 
             # Track first post with unverifiable links as fallback
             fallback_links = None
@@ -137,6 +138,33 @@ class Source(AbstractDownloadSource):
             return {"links": [], "password": ""}
 
 
+def _posts_matching_requested_fragment(posts, url):
+    fragment = urlparse(url).fragment
+    if not fragment:
+        return posts
+
+    normalized_fragment = _normalize_post_fragment(fragment)
+    matched_posts = [
+        post for post in posts if _post_matches_fragment(post, normalized_fragment)
+    ]
+    return matched_posts or posts
+
+
+def _post_matches_fragment(post, normalized_fragment):
+    candidates = {
+        _normalize_post_fragment(post.get("id")),
+        _normalize_post_fragment(post.get("data-content")),
+    }
+
+    return normalized_fragment in candidates
+
+
+def _normalize_post_fragment(fragment):
+    normalized = str(fragment or "").strip().lstrip("#").lower()
+    normalized = re.sub(r"^js-", "", normalized)
+    return normalized
+
+
 def _normalize_mirror_name(name):
     """
     Normalize mirror/provider names to a provider root token.
@@ -164,7 +192,7 @@ def _normalize_mirror_name(name):
     # Handle alternative spellings/shorthands
     if normalized in ["rg"]:
         return "rapidgator"
-    if normalized in ["ddl"]:
+    if normalized in ["ddl", "ddlto"]:
         return "ddownload"
 
     return normalized
@@ -344,6 +372,19 @@ def _detect_supported_crypter(href):
     return None
 
 
+def _detect_direct_hoster(href):
+    parsed = urlparse(href)
+    host = (parsed.netloc or "").lower()
+    if host.startswith("www."):
+        host = host[4:]
+
+    hoster = _normalize_mirror_name(host)
+    if hoster in SHARE_HOSTERS_LOWERCASE:
+        return hoster
+
+    return None
+
+
 def _build_filecrypt_status_map(soup):
     """
     Build a map of mirror names to FileCrypt status URLs.
@@ -433,9 +474,9 @@ def _extract_mirror_name_from_text(text):
     return None
 
 
-def _iter_plaintext_crypter_links(soup):
+def _iter_plaintext_download_links(soup):
     """
-    Yield crypter URLs rendered as text, preserving the last hoster heading.
+    Yield downloadable URLs rendered as text, preserving the last hoster heading.
     """
     current_mirror = None
 
@@ -458,7 +499,7 @@ def _iter_plaintext_crypter_links(soup):
 
             href = _clean_plaintext_url(match.group(0))
             crypter_type = _detect_supported_crypter(href)
-            if crypter_type:
+            if crypter_type or _detect_direct_hoster(href):
                 yield href, crypter_type, current_mirror
 
             search_start = match.end()
@@ -484,11 +525,20 @@ def _extract_links_and_password_from_post(post_content, host, requested_mirrors=
         if href.startswith("/") or host in href:
             return
 
+        direct_hoster = None
         if not crypter_type:
+            direct_hoster = _detect_direct_hoster(href)
+        if not crypter_type and not direct_hoster:
             debug(f"Unsupported link crypter/hoster found: {href}")
             return
 
-        normalized_mirror = _normalize_mirror_name(mirror_name) if mirror_name else None
+        normalized_mirror = (
+            direct_hoster
+            if direct_hoster
+            else _normalize_mirror_name(mirror_name)
+            if mirror_name
+            else None
+        )
 
         if requested_mirrors and normalized_mirror:
             if normalized_mirror not in requested_mirrors:
@@ -497,11 +547,13 @@ def _extract_links_and_password_from_post(post_content, host, requested_mirrors=
         identifier = normalized_mirror if normalized_mirror else crypter_type
 
         # Get status URL - try extraction first, then status map, then generation
-        status_url = (
-            _extract_status_url_from_html(link_element, crypter_type)
-            if link_element
-            else None
-        )
+        status_url = None
+        if crypter_type:
+            status_url = (
+                _extract_status_url_from_html(link_element, crypter_type)
+                if link_element
+                else None
+            )
 
         if not status_url and crypter_type == "filecrypt" and normalized_mirror:
             # Try to find in status map by mirror name (normalized, case-insensitive, TLD-stripped)
@@ -516,19 +568,20 @@ def _extract_links_and_password_from_post(post_content, host, requested_mirrors=
                     status_url = map_url
                     break
 
-        if not status_url:
+        if not status_url and crypter_type:
             status_url = generate_status_url(href, crypter_type)
 
         # Avoid duplicates (check href and identifier)
         if not any(l[0] == href and l[1] == identifier for l in links):
             links.append([href, identifier, status_url])
             status_info = f"status: {status_url}" if status_url else "no status URL"
+            link_type = crypter_type or "direct"
             if mirror_name:
                 debug(
-                    f"Found {crypter_type} link for mirror: {mirror_name} ({status_info})"
+                    f"Found {link_type} link for mirror: {mirror_name} ({status_info})"
                 )
             else:
-                debug(f"Found {crypter_type} link ({status_info})")
+                debug(f"Found {link_type} link ({status_info})")
 
     for link in soup.find_all("a", href=True):
         href = link.get("href")
@@ -540,7 +593,7 @@ def _extract_links_and_password_from_post(post_content, host, requested_mirrors=
             link_element=link,
         )
 
-    for href, crypter_type, mirror_name in _iter_plaintext_crypter_links(soup):
+    for href, crypter_type, mirror_name in _iter_plaintext_download_links(soup):
         add_link(href, crypter_type, mirror_name=mirror_name)
 
     password = ""

--- a/quasarr/providers/version.py
+++ b/quasarr/providers/version.py
@@ -5,7 +5,7 @@
 import re
 import sys
 
-__version__ = "4.4.1"
+__version__ = "4.4.2"
 
 
 def get_version():

--- a/quasarr/search/sources/dl.py
+++ b/quasarr/search/sources/dl.py
@@ -6,6 +6,7 @@ import re
 import time
 from datetime import datetime
 from html import unescape
+from urllib.parse import urlsplit, urlunsplit
 
 from bs4 import BeautifulSoup
 
@@ -18,6 +19,7 @@ from quasarr.constants import (
     SEARCH_CAT_MUSIC,
     SEARCH_CAT_SHOWS,
     SEARCH_REQUEST_TIMEOUT_SECONDS,
+    SHARE_HOSTERS_LOWERCASE,
     XXX_REGEX,
 )
 from quasarr.providers import shared_state
@@ -316,6 +318,21 @@ class Source(AbstractSearchSource):
                         }
                     )
 
+                    if _is_current_year_jahresthema_thread(
+                        title, search_string, base_search_category
+                    ):
+                        page_releases.extend(
+                            _expand_jahresthema_thread_releases(
+                                shared_state,
+                                host,
+                                thread_url,
+                                search_string,
+                                imdb_id,
+                                self.initials,
+                                search_category,
+                            )
+                        )
+
                 except Exception as e:
                     debug(f"[Page {page_num}] error parsing item: {e}")
 
@@ -461,3 +478,407 @@ def _normalize_title_for_arr(title):
     title = re.sub(r"\.{2,}", ".", title)
     title = title.strip(".")
     return title
+
+
+def _is_current_year_jahresthema_thread(title, search_string, base_search_category):
+    if base_search_category != SEARCH_CAT_BOOKS:
+        return False
+
+    title_text = str(title or "")
+    title_lower = title_text.lower()
+    current_year = str(datetime.now().year)
+
+    if "jahresthema" not in title_lower and "sammelthema" not in title_lower:
+        return False
+    if current_year not in title_text:
+        return False
+
+    return _magazine_title_matches(search_string, title_text)
+
+
+def _magazine_title_matches(search_string, title):
+    search_tokens = set(_magazine_match_tokens(search_string))
+    title_tokens = set(_magazine_match_tokens(title))
+
+    if not search_tokens or not title_tokens:
+        return False
+
+    return search_tokens.issubset(title_tokens)
+
+
+def _magazine_match_tokens(text):
+    text = replace_umlauts(unescape(str(text or ""))).lower()
+    text = re.sub(r"\bc\s*['`´’]?\s*t\b", "ct", text)
+    text = re.sub(r"[^a-z0-9]+", " ", text)
+
+    ignored = {
+        "der",
+        "die",
+        "das",
+        "the",
+        "magazin",
+        "magazine",
+        "nachrichtenmagazin",
+        "zeitschrift",
+        "jahresthema",
+        "sammelthema",
+        "jahrgang",
+    }
+
+    tokens = []
+    for token in text.split():
+        if token in ignored:
+            continue
+        if re.fullmatch(r"(?:19|20)\d{2}", token):
+            continue
+        tokens.append(token)
+
+    return tokens
+
+
+def _expand_jahresthema_thread_releases(
+    shared_state,
+    host,
+    thread_url,
+    search_string,
+    imdb_id,
+    source_key,
+    search_category,
+):
+    releases = []
+    seen = set()
+
+    try:
+        first_page = _fetch_thread_page(shared_state, thread_url)
+        if first_page is None:
+            return releases
+
+        last_page = _extract_last_thread_page(first_page.text)
+        start_page = max(1, last_page - 4)
+
+        page_responses = {}
+        if start_page == 1:
+            page_responses[1] = first_page
+
+        for page_num in range(start_page, last_page + 1):
+            response = page_responses.get(page_num)
+            page_url = _thread_page_url(thread_url, page_num)
+            if response is None:
+                response = _fetch_thread_page(shared_state, page_url)
+            if response is None:
+                continue
+
+            soup = BeautifulSoup(response.text, "html.parser")
+            for post in soup.select("article.message--post"):
+                release = _release_from_jahresthema_post(
+                    shared_state,
+                    host,
+                    post,
+                    page_url,
+                    search_string,
+                    imdb_id,
+                    source_key,
+                    search_category,
+                )
+                if not release:
+                    continue
+
+                dedupe_key = release["details"]["title"].strip().casefold()
+                if dedupe_key in seen:
+                    continue
+                seen.add(dedupe_key)
+                releases.append(release)
+
+    except Exception as e:
+        debug(f"error expanding Jahresthema thread {thread_url}: {e}")
+
+    if releases:
+        trace(f"Expanded Jahresthema thread {thread_url} into {len(releases)} issues")
+    return releases
+
+
+def _fetch_thread_page(shared_state, page_url):
+    response = fetch_via_requests_session(
+        shared_state,
+        method="GET",
+        target_url=page_url,
+        timeout=SEARCH_REQUEST_TIMEOUT_SECONDS,
+    )
+    if response.status_code != 200:
+        debug(f"Jahresthema page returned status {response.status_code}: {page_url}")
+        return None
+    return response
+
+
+def _extract_last_thread_page(html):
+    soup = BeautifulSoup(html, "html.parser")
+    page_numbers = [1]
+
+    for element in soup.select("a.pageNav-page, .pageNav-main a, a.pageNav-jump"):
+        text = element.get_text(" ", strip=True)
+        if text.isdigit():
+            page_numbers.append(int(text))
+
+        href = element.get("href", "")
+        match = re.search(r"(?:/page-|[?&]page=)(\d+)", href)
+        if match:
+            page_numbers.append(int(match.group(1)))
+
+    return max(page_numbers)
+
+
+def _thread_page_url(thread_url, page_num):
+    split_url = urlsplit(thread_url)
+    path = re.sub(r"/page-\d+/?$", "", split_url.path.rstrip("/"))
+    if page_num > 1:
+        path = f"{path}/page-{page_num}"
+
+    return urlunsplit(
+        (
+            split_url.scheme,
+            split_url.netloc,
+            path,
+            split_url.query,
+            "",
+        )
+    )
+
+
+def _release_from_jahresthema_post(
+    shared_state,
+    host,
+    post,
+    page_url,
+    search_string,
+    imdb_id,
+    source_key,
+    search_category,
+):
+    if not _post_contains_supported_download(post):
+        return None
+
+    current_year = datetime.now().year
+    issue_title = _extract_issue_title_from_post(post, search_string)
+    if not issue_title:
+        return None
+
+    issue_title = _complete_issue_title(issue_title, search_string, current_year)
+    title_normalized = _normalize_title_for_arr(issue_title)
+
+    if not is_valid_release(title_normalized, search_category, search_string):
+        return None
+
+    post_url = _post_url(page_url, post)
+    date_elem = post.select_one("time.u-dt")
+    iso_date = date_elem.get("datetime", "") if date_elem else ""
+    published = _convert_to_rss_date(iso_date)
+
+    mb = 0
+    password = ""
+    link = generate_download_link(
+        shared_state,
+        title_normalized,
+        post_url,
+        mb,
+        password,
+        imdb_id or "",
+        source_key,
+    )
+
+    return {
+        "details": {
+            "title": title_normalized,
+            "hostname": source_key,
+            "imdb_id": imdb_id,
+            "link": link,
+            "size": mb * 1024 * 1024,
+            "date": published,
+            "source": post_url,
+        },
+        "type": "protected",
+    }
+
+
+def _post_contains_supported_download(post):
+    content = _own_message_content(post)
+    for url in re.findall(r"https?://[^\s<>'\"]+", str(content), re.IGNORECASE):
+        host = urlsplit(url).netloc.lower()
+
+        direct_hoster = _normalize_direct_hoster_name(host)
+        if direct_hoster in SHARE_HOSTERS_LOWERCASE:
+            return True
+
+        if re.search(r"(?:filecrypt|hide|keeplinks|tolink)\.", host, re.IGNORECASE):
+            return True
+
+    return False
+
+
+def _normalize_direct_hoster_name(host):
+    normalized = str(host or "").lower().strip()
+    if "://" in normalized:
+        parsed = urlsplit(normalized)
+        normalized = parsed.netloc or parsed.path
+
+    if normalized.startswith("www."):
+        normalized = normalized[4:]
+
+    normalized = normalized.split("/", 1)[0]
+    normalized = normalized.split(":", 1)[0]
+    normalized = normalized.split(".", 1)[0]
+
+    if normalized == "rg":
+        return "rapidgator"
+    if normalized in {"ddl", "ddlto"}:
+        return "ddownload"
+    return normalized
+
+
+def _extract_issue_title_from_post(post, search_string):
+    content = _own_message_content(post)
+
+    for selector in ("h1", "h2", "h3", "h4", "strong", "b"):
+        for element in content.select(selector):
+            candidate = _clean_issue_title(element.get_text(" ", strip=True))
+            if _looks_like_issue_title(candidate, search_string):
+                return candidate
+
+    text = content.get_text("\n", strip=True)
+    for line in text.splitlines():
+        candidate = _clean_issue_title(line)
+        if _looks_like_issue_title(candidate, search_string):
+            return candidate
+
+    return ""
+
+
+def _own_message_content(post):
+    content = post.select_one("div.bbWrapper") or post
+    soup = BeautifulSoup(str(content), "html.parser")
+
+    for element in soup.find_all("blockquote"):
+        element.decompose()
+
+    for element in soup.find_all(class_=True):
+        classes = " ".join(str(class_name).lower() for class_name in element["class"])
+        if "quote" in classes:
+            element.decompose()
+
+    return soup
+
+
+def _clean_issue_title(title):
+    title = unescape(str(title or ""))
+    title = re.sub(r"https?://\S+", " ", title)
+    title = re.sub(r"\s+", " ", title).strip(" -:|")
+    return title
+
+
+def _looks_like_issue_title(title, search_string):
+    if not title or len(title) < 3 or len(title) > 180:
+        return False
+
+    title_lower = title.lower()
+    if title_lower in {
+        "download",
+        "mirror",
+        "rapidgator",
+        "ddownload",
+        "turbobit",
+        "nitroflare",
+        "filecrypt",
+        "keeplinks",
+    }:
+        return False
+    if re.search(r"(?:filecrypt|hide|keeplinks|tolink)\.", title_lower):
+        return False
+
+    if re.search(
+        r"\b(?:download|mirror|passwort|password|size|groesse|grosse|größe|mb|gb)\b",
+        replace_umlauts(title_lower),
+    ):
+        return False
+
+    normalized_title = replace_umlauts(title_lower)
+    has_issue_marker = re.search(
+        r"\b(?:nr|no|issue|ausgabe|heft)\.?\s*\d{1,3}(?:\s*/\s*\d{2,4})?\b",
+        normalized_title,
+        re.IGNORECASE,
+    )
+    has_year = re.search(r"\b(?:19|20)\d{2}\b", title)
+    has_date_context = _has_issue_date_context(normalized_title)
+    has_magazine = _magazine_title_matches(search_string, title)
+
+    return bool(
+        (has_magazine and (has_issue_marker or has_date_context))
+        or (has_issue_marker and (has_year or has_date_context or has_magazine))
+        or (has_date_context and (has_magazine or has_issue_marker))
+    )
+
+
+def _has_issue_date_context(normalized_title):
+    month_pattern = (
+        r"january|february|march|april|may|june|july|august|september|october|"
+        r"november|december|januar|februar|maerz|marz|april|mai|juni|juli|"
+        r"august|september|oktober|november|dezember"
+    )
+    if re.search(
+        rf"\b(?:\d{{1,2}}\s+)?(?:{month_pattern})\s+(?:19|20)\d{{2}}\b",
+        normalized_title,
+    ):
+        return True
+    if re.search(
+        rf"\b\d{{1,2}}\.\s*(?:{month_pattern})\s+(?:19|20)\d{{2}}\b",
+        normalized_title,
+    ):
+        return True
+    if re.search(r"\b\d{1,3}\s*/\s*(?:19|20)\d{2}\b", normalized_title):
+        return True
+    if re.search(r"\b\d{1,3}\s+(?:19|20)\d{2}\b", normalized_title):
+        return True
+    if re.search(r"\b\d{1,2}[./-]\d{1,2}[./-]\d{2,4}\b", normalized_title):
+        return True
+
+    return False
+
+
+def _complete_issue_title(issue_title, search_string, current_year):
+    completed = issue_title
+
+    if not _magazine_title_matches(search_string, completed):
+        completed = f"{search_string} {completed}"
+    if not re.search(r"(?:19|20)\d{2}", completed):
+        completed = f"{completed} {current_year}"
+
+    return completed
+
+
+def _post_url(page_url, post):
+    fragment = _post_fragment(post)
+    if not fragment:
+        return page_url
+
+    split_url = urlsplit(page_url)
+    return urlunsplit(
+        (
+            split_url.scheme,
+            split_url.netloc,
+            split_url.path,
+            split_url.query,
+            fragment,
+        )
+    )
+
+
+def _post_fragment(post):
+    for attr in ("data-content", "id"):
+        value = str(post.get(attr) or "").strip("#")
+        if value:
+            return value
+
+    for link in post.select("a[href]"):
+        fragment = urlsplit(link.get("href", "")).fragment
+        if fragment:
+            return fragment
+
+    return ""

--- a/tests/test_dl_jahresthema.py
+++ b/tests/test_dl_jahresthema.py
@@ -1,0 +1,568 @@
+# -*- coding: utf-8 -*-
+
+import unittest
+from datetime import datetime
+from unittest.mock import patch
+
+from bs4 import BeautifulSoup
+
+from quasarr.constants import SEARCH_CAT_BOOKS
+from quasarr.downloads.sources.dl import Source as DownloadSource
+from quasarr.search.sources.dl import (
+    Source as SearchSource,
+)
+from quasarr.search.sources.dl import (
+    _expand_jahresthema_thread_releases,
+    _is_current_year_jahresthema_thread,
+    _post_contains_supported_download,
+    _release_from_jahresthema_post,
+)
+
+
+class FakeResponse:
+    def __init__(self, text, url="https://www.source.invalid/", status_code=200):
+        self.text = text
+        self.content = text.encode("utf-8")
+        self.url = url
+        self.status_code = status_code
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise RuntimeError(f"status {self.status_code}")
+
+
+class FakeSharedState:
+    def __init__(self):
+        self.values = {
+            "internal_address": "http://internal.invalid",
+            "config": self.config,
+        }
+
+    def config(self, section):
+        if section == "Hostnames":
+            return {"dl": "source.invalid"}
+        return {}
+
+
+class DlJahresthemaSearchTests(unittest.TestCase):
+    def test_matches_compact_ct_style_spelling(self):
+        current_year = datetime.now().year
+
+        self.assertTrue(
+            _is_current_year_jahresthema_thread(
+                f"C T Sample Jahresthema {current_year}",
+                "ct",
+                SEARCH_CAT_BOOKS,
+            )
+        )
+
+    def test_matches_common_magazine_title_shapes(self):
+        current_year = datetime.now().year
+
+        cases = [
+            (
+                f"The Sample News Magazine Jahresthema {current_year}",
+                "Sample News",
+            ),
+            (
+                f"Singleword Magazine Jahresthema {current_year}",
+                "Singleword",
+            ),
+            (
+                f"PC Sample Magazine Jahresthema {current_year}",
+                "PC Sample",
+            ),
+        ]
+
+        for thread_title, search_string in cases:
+            with self.subTest(search_string=search_string):
+                self.assertTrue(
+                    _is_current_year_jahresthema_thread(
+                        thread_title,
+                        search_string,
+                        SEARCH_CAT_BOOKS,
+                    )
+                )
+
+    def test_does_not_match_partial_magazine_title(self):
+        current_year = datetime.now().year
+
+        self.assertFalse(
+            _is_current_year_jahresthema_thread(
+                f"PC Different Magazine Jahresthema {current_year}",
+                "PC Sample",
+                SEARCH_CAT_BOOKS,
+            )
+        )
+
+    def test_expands_only_current_year_jahresthema_last_five_pages(self):
+        current_year = datetime.now().year
+        previous_year = current_year - 1
+        fetched_thread_urls = []
+
+        search_html = f"""
+            <html>
+                <li class="block-row">
+                    <h3 class="contentRow-title">
+                        <a href="/threads/sample-magazine-issue-001.1/">Sample Magazine Issue 001</a>
+                    </h3>
+                    <time class="u-dt" datetime="{current_year}-01-01T10:00:00+0100"></time>
+                </li>
+                <li class="block-row">
+                    <h3 class="contentRow-title">
+                        <a href="/threads/sample-magazine-jahresthema-{current_year}.2/">Sample Magazine Jahresthema {current_year}</a>
+                    </h3>
+                    <time class="u-dt" datetime="{current_year}-01-02T10:00:00+0100"></time>
+                </li>
+                <li class="block-row">
+                    <h3 class="contentRow-title">
+                        <a href="/threads/sample-magazine-jahresthema-{previous_year}.3/">Sample Magazine Jahresthema {previous_year}</a>
+                    </h3>
+                    <time class="u-dt" datetime="{current_year}-01-03T10:00:00+0100"></time>
+                </li>
+                <li class="block-row">
+                    <h3 class="contentRow-title">
+                        <a href="/threads/other-title-jahresthema-{current_year}.4/">Other Title Jahresthema {current_year}</a>
+                    </h3>
+                    <time class="u-dt" datetime="{current_year}-01-04T10:00:00+0100"></time>
+                </li>
+            </html>
+        """
+
+        first_thread_page = """
+            <html>
+                <a class="pageNav-page" href="/threads/sample-magazine-jahresthema/page-6">6</a>
+                <a class="pageNav-page" href="/threads/sample-magazine-jahresthema/page-7">7</a>
+            </html>
+        """
+
+        def thread_page(page_num):
+            return f"""
+                <html>
+                    <article class="message--post" data-content="post-{page_num}">
+                        <div class="bbWrapper">
+                            <h3>Sample Magazine Issue {page_num}</h3>
+                            <b>RapidGator</b>
+                            <a href="https://filecrypt.invalid/Container/{page_num}.html">Download</a>
+                        </div>
+                        <time class="u-dt" datetime="{current_year}-02-{page_num:02d}T10:00:00+0100"></time>
+                    </article>
+                </html>
+            """
+
+        def fake_fetch(
+            _shared_state, method, target_url, get_params=None, timeout=None
+        ):
+            if target_url.endswith("/search/search"):
+                return FakeResponse(
+                    search_html,
+                    url="https://www.source.invalid/search/123/",
+                )
+            if target_url.endswith("/search/123/"):
+                return FakeResponse("<html></html>", url=target_url)
+
+            fetched_thread_urls.append(target_url)
+            if target_url.endswith(f"jahresthema-{current_year}.2/"):
+                return FakeResponse(first_thread_page, url=target_url)
+
+            for page_num in range(3, 8):
+                if target_url.endswith(f"jahresthema-{current_year}.2/page-{page_num}"):
+                    return FakeResponse(thread_page(page_num), url=target_url)
+
+            raise AssertionError(f"unexpected fetch: {target_url}")
+
+        with (
+            patch(
+                "quasarr.search.sources.dl.retrieve_and_validate_session",
+                return_value=object(),
+            ),
+            patch("quasarr.search.sources.dl.fetch_via_requests_session", fake_fetch),
+            patch(
+                "quasarr.search.sources.dl.generate_download_link",
+                side_effect=lambda _state, title, url, *_args: (
+                    f"download:{title}:{url}"
+                ),
+            ),
+            patch("quasarr.search.sources.dl.clear_hostname_issue"),
+        ):
+            releases = SearchSource().search(
+                FakeSharedState(),
+                0,
+                SEARCH_CAT_BOOKS,
+                "Sample Magazine",
+            )
+
+        titles = [release["details"]["title"] for release in releases]
+
+        self.assertIn(f"Sample.Magazine.Issue.3.{current_year}", titles)
+        self.assertIn(f"Sample.Magazine.Issue.7.{current_year}", titles)
+        self.assertNotIn(f"Sample.Magazine.Issue.2.{current_year}", titles)
+        self.assertEqual(
+            [
+                f"https://www.source.invalid/threads/sample-magazine-jahresthema-{current_year}.2/",
+                f"https://www.source.invalid/threads/sample-magazine-jahresthema-{current_year}.2/page-3",
+                f"https://www.source.invalid/threads/sample-magazine-jahresthema-{current_year}.2/page-4",
+                f"https://www.source.invalid/threads/sample-magazine-jahresthema-{current_year}.2/page-5",
+                f"https://www.source.invalid/threads/sample-magazine-jahresthema-{current_year}.2/page-6",
+                f"https://www.source.invalid/threads/sample-magazine-jahresthema-{current_year}.2/page-7",
+            ],
+            fetched_thread_urls,
+        )
+
+    def test_rejects_metadata_lines_as_issue_titles(self):
+        current_year = datetime.now().year
+        post_html = """
+            <article class="message--post" data-content="post-1">
+                <div class="bbWrapper">
+                    <b>RapidGator</b>
+                    <p>Groesse: 120 MB</p>
+                    <p>Passwort: source.invalid</p>
+                    <a href="https://filecrypt.invalid/Container/1.html">Download</a>
+                </div>
+            </article>
+        """
+
+        with patch(
+            "quasarr.search.sources.dl.generate_download_link",
+            side_effect=lambda _state, title, url, *_args: f"download:{title}:{url}",
+        ):
+            release = _release_from_jahresthema_post(
+                FakeSharedState(),
+                "source.invalid",
+                BeautifulSoup(post_html, "html.parser").select_one(
+                    "article.message--post"
+                ),
+                "https://www.source.invalid/threads/sample.1/page-2",
+                "Sample Magazine",
+                None,
+                "dl",
+                SEARCH_CAT_BOOKS,
+            )
+
+        self.assertIsNone(release)
+
+        year_note_post_html = f"""
+            <article class="message--post" data-content="post-1">
+                <div class="bbWrapper">
+                    <p>Updated mirrors for {current_year}</p>
+                    <p>Mirror 1</p>
+                    <a href="https://rapidgator.invalid/file/abc">Download</a>
+                </div>
+            </article>
+        """
+
+        with patch(
+            "quasarr.search.sources.dl.generate_download_link",
+            side_effect=lambda _state, title, url, *_args: f"download:{title}:{url}",
+        ):
+            year_note_release = _release_from_jahresthema_post(
+                FakeSharedState(),
+                "source.invalid",
+                BeautifulSoup(year_note_post_html, "html.parser").select_one(
+                    "article.message--post"
+                ),
+                "https://www.source.invalid/threads/sample.1/page-2",
+                "Sample Magazine",
+                None,
+                "dl",
+                SEARCH_CAT_BOOKS,
+            )
+
+        self.assertIsNone(year_note_release)
+
+        quoted_issue_post_html = f"""
+            <article class="message--post" data-content="post-1">
+                <div class="bbWrapper">
+                    <blockquote class="bbCodeBlock bbCodeBlock--quote">
+                        <p>Sample Magazine Issue 12 {current_year}</p>
+                        <a href="https://rapidgator.invalid/file/quoted">Download</a>
+                    </blockquote>
+                    <p>Updated mirrors only.</p>
+                </div>
+            </article>
+        """
+
+        with patch(
+            "quasarr.search.sources.dl.generate_download_link",
+            side_effect=lambda _state, title, url, *_args: f"download:{title}:{url}",
+        ):
+            quoted_issue_release = _release_from_jahresthema_post(
+                FakeSharedState(),
+                "source.invalid",
+                BeautifulSoup(quoted_issue_post_html, "html.parser").select_one(
+                    "article.message--post"
+                ),
+                "https://www.source.invalid/threads/sample.1/page-2",
+                "Sample Magazine",
+                None,
+                "dl",
+                SEARCH_CAT_BOOKS,
+            )
+
+        self.assertIsNone(quoted_issue_release)
+
+        magazine_year_note_post_html = f"""
+            <article class="message--post" data-content="post-1">
+                <div class="bbWrapper">
+                    <p>Sample Magazine updated mirrors for {current_year}</p>
+                    <a href="https://rapidgator.invalid/file/abc">Download</a>
+                </div>
+            </article>
+        """
+
+        with patch(
+            "quasarr.search.sources.dl.generate_download_link",
+            side_effect=lambda _state, title, url, *_args: f"download:{title}:{url}",
+        ):
+            magazine_year_note_release = _release_from_jahresthema_post(
+                FakeSharedState(),
+                "source.invalid",
+                BeautifulSoup(magazine_year_note_post_html, "html.parser").select_one(
+                    "article.message--post"
+                ),
+                "https://www.source.invalid/threads/sample.1/page-2",
+                "Sample Magazine",
+                None,
+                "dl",
+                SEARCH_CAT_BOOKS,
+            )
+
+        self.assertIsNone(magazine_year_note_release)
+
+        valid_post_html = f"""
+            <article class="message--post" data-content="post-2">
+                <div class="bbWrapper">
+                    <p>Sample Magazine 12 {current_year}</p>
+                    <b>RapidGator</b>
+                    <a href="https://filecrypt.invalid/Container/2.html">Download</a>
+                </div>
+            </article>
+        """
+
+        with patch(
+            "quasarr.search.sources.dl.generate_download_link",
+            side_effect=lambda _state, title, url, *_args: f"download:{title}:{url}",
+        ):
+            valid_release = _release_from_jahresthema_post(
+                FakeSharedState(),
+                "source.invalid",
+                BeautifulSoup(valid_post_html, "html.parser").select_one(
+                    "article.message--post"
+                ),
+                "https://www.source.invalid/threads/sample.1/page-2",
+                "Sample Magazine",
+                None,
+                "dl",
+                SEARCH_CAT_BOOKS,
+            )
+
+        self.assertEqual(
+            f"Sample.Magazine.12.{current_year}",
+            valid_release["details"]["title"],
+        )
+
+    def test_does_not_append_current_year_to_title_with_existing_year(self):
+        previous_year = datetime.now().year - 1
+        post_html = f"""
+            <article class="message--post" data-content="post-1">
+                <div class="bbWrapper">
+                    <p>Issue 01 {previous_year}</p>
+                    <a href="https://rapidgator.invalid/file/abc">Download</a>
+                </div>
+            </article>
+        """
+
+        with patch(
+            "quasarr.search.sources.dl.generate_download_link",
+            side_effect=lambda _state, title, url, *_args: f"download:{title}:{url}",
+        ):
+            release = _release_from_jahresthema_post(
+                FakeSharedState(),
+                "source.invalid",
+                BeautifulSoup(post_html, "html.parser").select_one(
+                    "article.message--post"
+                ),
+                "https://www.source.invalid/threads/sample.1/page-2",
+                "Sample Magazine",
+                None,
+                "dl",
+                SEARCH_CAT_BOOKS,
+            )
+
+        self.assertEqual(
+            f"Sample.Magazine.Issue.01.{previous_year}",
+            release["details"]["title"],
+        )
+
+    def test_expanded_jahresthema_deduplicates_by_title(self):
+        current_year = datetime.now().year
+        thread_html = f"""
+            <html>
+                <article class="message--post" data-content="post-1">
+                    <div class="bbWrapper">
+                        <h3>Sample Magazine Issue 01 {current_year}</h3>
+                        <a href="https://rapidgator.invalid/file/abc">Download</a>
+                    </div>
+                    <time class="u-dt" datetime="{current_year}-01-01T10:00:00+0100"></time>
+                </article>
+                <article class="message--post" data-content="post-2">
+                    <div class="bbWrapper">
+                        <h3>Sample Magazine Issue 01 {current_year}</h3>
+                        <a href="https://ddownload.invalid/file/abc">Download</a>
+                    </div>
+                    <time class="u-dt" datetime="{current_year}-01-01T11:00:00+0100"></time>
+                </article>
+            </html>
+        """
+
+        with (
+            patch(
+                "quasarr.search.sources.dl.fetch_via_requests_session",
+                return_value=FakeResponse(thread_html),
+            ),
+            patch(
+                "quasarr.search.sources.dl.generate_download_link",
+                side_effect=lambda _state, title, url, *_args: (
+                    f"download:{title}:{url}"
+                ),
+            ),
+        ):
+            releases = _expand_jahresthema_thread_releases(
+                FakeSharedState(),
+                "source.invalid",
+                "https://www.source.invalid/threads/sample-magazine.1/",
+                "Sample Magazine",
+                None,
+                "dl",
+                SEARCH_CAT_BOOKS,
+            )
+
+        self.assertEqual(1, len(releases))
+        self.assertEqual(
+            f"Sample.Magazine.Issue.01.{current_year}",
+            releases[0]["details"]["title"],
+        )
+        self.assertTrue(releases[0]["details"]["source"].endswith("#post-1"))
+
+    def test_jahresthema_prefilter_accepts_hoster_aliases(self):
+        current_year = datetime.now().year
+
+        for host in ("rg.invalid", "ddl.invalid", "ddlto.invalid"):
+            with self.subTest(host=host):
+                post_html = f"""
+                    <article class="message--post" data-content="post-1">
+                        <div class="bbWrapper">
+                            <p>Sample Magazine Issue 01 {current_year}</p>
+                            <a href="https://{host}/file/abc">Download</a>
+                        </div>
+                    </article>
+                """
+                post = BeautifulSoup(post_html, "html.parser").select_one(
+                    "article.message--post"
+                )
+
+                self.assertTrue(_post_contains_supported_download(post))
+
+                with patch(
+                    "quasarr.search.sources.dl.generate_download_link",
+                    side_effect=lambda _state, title, url, *_args: (
+                        f"download:{title}:{url}"
+                    ),
+                ):
+                    release = _release_from_jahresthema_post(
+                        FakeSharedState(),
+                        "source.invalid",
+                        post,
+                        "https://www.source.invalid/threads/sample.1/page-2",
+                        "Sample Magazine",
+                        None,
+                        "dl",
+                        SEARCH_CAT_BOOKS,
+                    )
+
+                self.assertIsNotNone(release)
+
+    def test_jahresthema_prefilter_keeps_spoiler_download_links(self):
+        current_year = datetime.now().year
+        post_html = f"""
+            <article class="message--post" data-content="post-1">
+                <div class="bbWrapper">
+                    <p>Sample Magazine Issue 01 {current_year}</p>
+                    <div class="bbCodeSpoiler">
+                        <a href="https://rapidgator.invalid/file/abc">Download</a>
+                    </div>
+                </div>
+            </article>
+        """
+        post = BeautifulSoup(post_html, "html.parser").select_one(
+            "article.message--post"
+        )
+
+        self.assertTrue(_post_contains_supported_download(post))
+
+        with patch(
+            "quasarr.search.sources.dl.generate_download_link",
+            side_effect=lambda _state, title, url, *_args: f"download:{title}:{url}",
+        ):
+            release = _release_from_jahresthema_post(
+                FakeSharedState(),
+                "source.invalid",
+                post,
+                "https://www.source.invalid/threads/sample.1/page-2",
+                "Sample Magazine",
+                None,
+                "dl",
+                SEARCH_CAT_BOOKS,
+            )
+
+        self.assertIsNotNone(release)
+
+
+class DlJahresthemaDownloadTests(unittest.TestCase):
+    def test_download_prefers_requested_post_fragment(self):
+        thread_html = """
+            <html>
+                <article class="message--post" data-content="post-1">
+                    <div class="bbWrapper">
+                        <h3>Sample Magazine Issue 1</h3>
+                        <a href="#post-2">quoted post reference</a>
+                        <b>RapidGator</b>
+                        <a href="https://keeplinks.invalid/p/first">Download</a>
+                    </div>
+                </article>
+                <article class="message--post" data-content="post-2">
+                    <div class="bbWrapper">
+                        <h3>Sample Magazine Issue 2</h3>
+                        <b>RapidGator</b>
+                        <a href="https://keeplinks.invalid/p/second">Download</a>
+                    </div>
+                </article>
+            </html>
+        """
+
+        with (
+            patch(
+                "quasarr.downloads.sources.dl.retrieve_and_validate_session",
+                return_value=object(),
+            ),
+            patch(
+                "quasarr.downloads.sources.dl.fetch_via_requests_session",
+                return_value=FakeResponse(thread_html),
+            ),
+        ):
+            result = DownloadSource().get_download_links(
+                FakeSharedState(),
+                "https://www.source.invalid/threads/sample-magazine.1/page-2#post-2",
+                [],
+                "Sample Magazine Issue 2",
+                "",
+            )
+
+        self.assertEqual(
+            [["https://keeplinks.invalid/p/second", "rapidgator"]],
+            result["links"],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_dl_plaintext_links.py
+++ b/tests/test_dl_plaintext_links.py
@@ -94,6 +94,56 @@ class DlPlaintextLinksTests(unittest.TestCase):
             links,
         )
 
+    def test_extracts_direct_hoster_urls(self):
+        post_html = """
+            <div class="bbWrapper">
+                <a href="https://rapidgator.invalid/file/abc">Download</a>
+                <a href="https://ddownload.invalid/example.pdf">Download</a>
+                <a href="https://ddlto.invalid/example.pdf">Download</a>
+                <a href="https://unknown.invalid/example.pdf">Unknown</a>
+            </div>
+        """
+
+        links, password = _extract_links_and_password_from_post(
+            post_html,
+            "source.invalid",
+            set(),
+        )
+
+        self.assertEqual(
+            [
+                ["https://rapidgator.invalid/file/abc", "rapidgator", None],
+                ["https://ddownload.invalid/example.pdf", "ddownload", None],
+                ["https://ddlto.invalid/example.pdf", "ddownload", None],
+            ],
+            links,
+        )
+        self.assertEqual("www.source.invalid", password)
+
+    def test_extracts_plaintext_direct_hoster_urls(self):
+        post_html = """
+            <div class="bbWrapper">
+                <b>DDownload</b>
+                <pre>https://ddownload.invalid/example.pdf</pre>
+                <b>Rapidgator</b>
+                <pre>https://rapidgator.invalid/file/abc</pre>
+            </div>
+        """
+
+        links, _ = _extract_links_and_password_from_post(
+            post_html,
+            "source.invalid",
+            set(),
+        )
+
+        self.assertEqual(
+            [
+                ["https://ddownload.invalid/example.pdf", "ddownload", None],
+                ["https://rapidgator.invalid/file/abc", "rapidgator", None],
+            ],
+            links,
+        )
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## 📰 What changed

- Detects current-year DL `Jahresthema` / `Sammelthema` threads for document searches.
- Expands matching yearly magazine threads into individual issue releases from the last five thread pages.
- Emits exact post URLs for expanded issues so downloads resolve the intended magazine issue.
- Updates the DL download handler to prefer the requested post fragment before falling back to the full page scan.
- Adds direct hoster extraction for DL posts, including plaintext direct hoster URLs, while keeping existing crypter extraction intact.
- Adds focused tests for current-year filtering, last-five-page request budgeting, exact post download handling, crypter extraction, and direct hoster extraction.

## 🎯 Why

Magazarr searches usually ask for broad magazine titles, while DL often stores current issues inside yearly collection threads. Returning only the yearly thread hides many issues. Expanding the current-year collection exposes recent issues without blowing up request volume.

## 🚀 Impact

Document searches for magazine titles can now surface many more current-year DL magazine issues while ignoring older yearly threads. Downloads work for exact yearly-thread posts, direct hoster links, plaintext direct links, and the existing protected crypter links.