### PR TITLE
fix: validate AL CAPTCHA on the solving requests.Session (#382)

### DIFF
--- a/docs/sources/AL.md
+++ b/docs/sources/AL.md
@@ -15,6 +15,7 @@ Per-source notes for the `AL` integration. For conventions that apply to every s
 - Module: `quasarr/downloads/sources/al.py`
 - Inherits: `AbstractDownloadSource`
 - Link protection: handled in `quasarr/downloads/linkcrypters/al.py` (CAPTCHA solving and content decryption); FlareSolverr is required for the download flow.
+- CAPTCHA flow: the details page and the initial `/ajax/captcha` (`nocaptcha`) request run on the FlareSolverr browser session to arm the challenge. The CAPTCHA solve (icon fetch + selection submit on `/files/captcha`) and the final `/ajax/captcha` (`captcha`) validation must run on the same `requests.Session`, because AL binds a solved CAPTCHA to the client that solved it — validating from the FlareSolverr browser instead is rejected with `The captcha ID was invalid`. CAPTCHA POST requests include browser-style AJAX headers, and the requests session keeps the current FlareSolverr User-Agent so it stays browser-consistent.
 
 ## Notable quirks
 

--- a/quasarr/downloads/linkcrypters/al.py
+++ b/quasarr/downloads/linkcrypters/al.py
@@ -177,7 +177,12 @@ def calculate_pixel_based_difference(img1, img2):
 
 
 def solve_captcha(
-    hostname, shared_state, fetch_via_flaresolverr, fetch_via_requests_session
+    hostname,
+    shared_state,
+    fetch_via_flaresolverr,
+    fetch_via_requests_session,
+    session_id=None,
+    request_headers=None,
 ):
     # Check if FlareSolverr is available
     if not is_flaresolverr_available(shared_state):
@@ -189,18 +194,19 @@ def solve_captcha(
     al = shared_state.values["config"]("Hostnames").get(hostname)
     captcha_base = f"https://www.{al}/files/captcha"
 
-    result = fetch_via_flaresolverr(
+    response = fetch_via_requests_session(
         shared_state,
         method="POST",
         target_url=captcha_base,
         post_data={"cID": 0, "rT": 1},
         timeout=DOWNLOAD_REQUEST_TIMEOUT_SECONDS,
+        request_headers=request_headers,
     )
 
     try:
-        image_ids = result["json"]
+        image_ids = response.json()
     except ValueError as e:
-        raise RuntimeError(f"Cannot decode captcha IDs: {result['text']}") from e
+        raise RuntimeError(f"Cannot decode captcha IDs: {response.text}") from e
 
     if not isinstance(image_ids, list) or len(image_ids) < 2:
         raise RuntimeError("Unexpected captcha IDs format.")
@@ -262,12 +268,13 @@ def solve_captcha(
         f'CAPTCHA image "{identified_captcha_image}" - difference to others: {different_pixels_percentage}%'
     )
 
-    result = fetch_via_flaresolverr(
+    response = fetch_via_requests_session(
         shared_state,
         method="POST",
         target_url=captcha_base,
         post_data={"cID": 0, "pC": identified_captcha_image, "rT": 2},
         timeout=DOWNLOAD_REQUEST_TIMEOUT_SECONDS,
+        request_headers=request_headers,
     )
 
-    return {"response": result["text"], "captcha_id": identified_captcha_image}
+    return {"response": response.text, "captcha_id": identified_captcha_image}

--- a/quasarr/downloads/sources/al.py
+++ b/quasarr/downloads/sources/al.py
@@ -29,6 +29,10 @@ from quasarr.downloads.sources.helpers.anime_title import (
 from quasarr.downloads.sources.helpers.anime_title import (
     subtitle_tokens as _shared_subtitle_tokens,
 )
+from quasarr.providers.cloudflare import (
+    flaresolverr_create_session,
+    flaresolverr_destroy_session,
+)
 from quasarr.providers.hostname_issues import mark_hostname_issue
 from quasarr.providers.log import debug, info, trace
 from quasarr.providers.sessions.al import (
@@ -71,42 +75,46 @@ class Source(AbstractDownloadSource):
             mark_hostname_issue(Source.initials, "download", "Session error")
             return {}
 
-        details_page = fetch_via_flaresolverr(
-            shared_state,
-            "GET",
-            url,
-            timeout=DOWNLOAD_REQUEST_TIMEOUT_SECONDS,
-        )
-        details_html = details_page.get("text", "")
-        if not details_html:
-            info(f"Failed to load details page for {title} at {url}")
-            return {}
-
-        episode_in_title = _extract_episode(title)
-        if episode_in_title:
-            selection = episode_in_title - 1  # Convert to zero-based index
-        else:
-            selection = "cnl"
-
-        title, release_id = _check_release(
-            shared_state, details_html, release_id, title, episode_in_title
-        )
-        if release_id == 0:
-            info(f"No valid release ID found for {title} - Download failed!")
-            return {}
-
-        anime_identifier = url.rstrip("/").split("/")[-1]
-
-        info(f'Selected "Release {release_id}" from {url}')
-
+        browser_session_id = flaresolverr_create_session(shared_state)
         links = []
         try:
+            details_page = fetch_via_flaresolverr(
+                shared_state,
+                "GET",
+                url,
+                timeout=DOWNLOAD_REQUEST_TIMEOUT_SECONDS,
+                session_id=browser_session_id,
+            )
+            details_html = details_page.get("text", "")
+            if not details_html:
+                info(f"Failed to load details page for {title} at {url}")
+                return {}
+
+            episode_in_title = _extract_episode(title)
+            if episode_in_title:
+                selection = episode_in_title - 1  # Convert to zero-based index
+            else:
+                selection = "cnl"
+
+            title, release_id = _check_release(
+                shared_state, details_html, release_id, title, episode_in_title
+            )
+            if release_id == 0:
+                info(f"No valid release ID found for {title} - Download failed!")
+                return {}
+
+            anime_identifier = url.rstrip("/").split("/")[-1]
+
+            info(f'Selected "Release {release_id}" from {url}')
+
             raw_request = json.dumps(
                 ["media", anime_identifier, "downloads", release_id, selection]
             )
             b64 = base64.b64encode(raw_request.encode("ascii")).decode("ascii")
 
             post_url = f"https://www.{al}/ajax/captcha"
+            ajax_headers = _build_ajax_headers()
+            captcha_headers = _build_captcha_headers(al, url)
             payload = {"enc": b64, "response": "nocaptcha"}
 
             result = fetch_via_flaresolverr(
@@ -115,6 +123,8 @@ class Source(AbstractDownloadSource):
                 target_url=post_url,
                 post_data=payload,
                 timeout=DOWNLOAD_REQUEST_TIMEOUT_SECONDS,
+                session_id=browser_session_id,
+                request_headers=ajax_headers,
             )
 
             status = result.get("status_code")
@@ -155,6 +165,8 @@ class Source(AbstractDownloadSource):
                                 shared_state,
                                 fetch_via_flaresolverr,
                                 fetch_via_requests_session,
+                                session_id=browser_session_id,
+                                request_headers=captcha_headers,
                             )
 
                             solved = (
@@ -169,18 +181,24 @@ class Source(AbstractDownloadSource):
                                     "captcha-idhf": 0,
                                     "captcha-hf": captcha_id,
                                 }
-                                check_solution = fetch_via_flaresolverr(
+                                # Validate through the same requests.Session that
+                                # solved the CAPTCHA (rT:1/images/rT:2). AL binds the
+                                # solved CAPTCHA to the solving client; validating via
+                                # the FlareSolverr browser hits a different cookie jar
+                                # and AL rejects it with "The captcha ID was invalid".
+                                check_solution = fetch_via_requests_session(
                                     shared_state,
                                     method="POST",
                                     target_url=post_url,
                                     post_data=payload,
                                     timeout=DOWNLOAD_REQUEST_TIMEOUT_SECONDS,
+                                    request_headers=ajax_headers,
                                 )
                                 try:
-                                    response_json = check_solution.get("json", {})
+                                    response_json = check_solution.json()
                                 except ValueError as e:
                                     raise RuntimeError(
-                                        f"Unexpected /ajax/captcha response: {check_solution.get('text', '')}"
+                                        f"Unexpected /ajax/captcha response: {check_solution.text}"
                                     ) from e
 
                                 code = response_json.get("code", "")
@@ -261,6 +279,9 @@ class Source(AbstractDownloadSource):
                 str(e) if "e" in dir() else "Download error",
             )
             invalidate_session(shared_state)
+        finally:
+            if browser_session_id:
+                flaresolverr_destroy_session(shared_state, browser_session_id)
 
         success = bool(links)
         if success:
@@ -271,6 +292,25 @@ class Source(AbstractDownloadSource):
         links_with_mirrors = [[url, _derive_mirror(url)] for url in links]
 
         return {"links": links_with_mirrors, "password": f"www.{al}", "title": title}
+
+
+def _build_ajax_headers():
+    return {
+        "Accept": "application/json, text/javascript, */*; q=0.01",
+        "Content-Type": "application/x-www-form-urlencoded; charset=UTF-8",
+        "X-Requested-With": "XMLHttpRequest",
+    }
+
+
+def _build_captcha_headers(al, referer):
+    headers = _build_ajax_headers()
+    headers.update(
+        {
+            "Origin": f"https://www.{al}",
+            "Referer": referer,
+        }
+    )
+    return headers
 
 
 def _roman_to_int(r: str) -> int:

--- a/quasarr/providers/sessions/al.py
+++ b/quasarr/providers/sessions/al.py
@@ -242,6 +242,8 @@ def fetch_via_flaresolverr(
     target_url: str,
     post_data: dict = None,
     timeout: int | None = None,
+    session_id: str | None = None,
+    request_headers: dict | None = None,
 ):
     """
     Load (or recreate) the requests.Session from DB.
@@ -254,6 +256,8 @@ def fetch_via_flaresolverr(
     - method: "GET" or "POST"
     - post_data: dict of form-fields if method=="POST"
     - timeout: seconds (FlareSolverr's internal maxTimeout = timeout*1000 ms)
+    - session_id: optional FlareSolverr browser session to reuse for stateful flows
+    - request_headers: optional headers for the browser request
     """
     if timeout is None:
         timeout = SESSION_REQUEST_TIMEOUT_SECONDS
@@ -295,6 +299,10 @@ def fetch_via_flaresolverr(
         # Inject every cookie from our Python session into FlareSolverr
         "cookies": _load_session_cookies_for_flaresolverr(sess),
     }
+    if session_id:
+        fs_payload["session"] = session_id
+    if request_headers:
+        fs_payload["headers"] = request_headers
 
     if method.upper() == "POST":
         # FlareSolverr expects postData as urlencoded string
@@ -332,6 +340,9 @@ def fetch_via_flaresolverr(
         )
 
     solution = fs_json["solution"]
+    user_agent = solution.get("userAgent")
+    if user_agent:
+        sess.headers.update({"User-Agent": user_agent})
 
     # Extract the raw HTML/JSON body that FlareSolverr fetched
     raw_body = solution.get("response", "")
@@ -374,6 +385,7 @@ def fetch_via_requests_session(
     post_data: dict = None,
     timeout: int | None = None,
     year: int = None,
+    request_headers: dict | None = None,
 ):
     """
     - method: "GET" or "POST"
@@ -397,10 +409,14 @@ def fetch_via_requests_session(
         trace("Removed year filter cookie")
 
     # Execute request
+    headers = dict(sess.headers)
+    if request_headers:
+        headers.update(request_headers)
+
     if method.upper() == "GET":
-        r = sess.get(target_url, timeout=timeout)
+        r = sess.get(target_url, headers=headers, timeout=timeout)
     else:  # POST
-        r = sess.post(target_url, data=post_data, timeout=timeout)
+        r = sess.post(target_url, data=post_data, headers=headers, timeout=timeout)
 
     r.raise_for_status()
 

--- a/quasarr/providers/version.py
+++ b/quasarr/providers/version.py
@@ -5,7 +5,7 @@
 import re
 import sys
 
-__version__ = "4.5.3"
+__version__ = "4.5.4"
 
 
 def get_version():

--- a/tests/test_al_flaresolverr_session.py
+++ b/tests/test_al_flaresolverr_session.py
@@ -1,0 +1,229 @@
+import unittest
+from unittest.mock import patch
+
+import requests
+
+from quasarr.downloads.sources.al import Source
+from quasarr.providers.sessions import al as al_sessions
+
+
+class SharedState:
+    def __init__(self):
+        self.values = {"config": self.config}
+
+    def config(self, section):
+        if section == "FlareSolverr":
+            return {"url": "http://solver.invalid/v1"}
+        if section == "Hostnames":
+            return {"al": "source.invalid"}
+        return {}
+
+
+class FlareSolverrResponse:
+    status_code = 200
+
+    def __init__(self, payload):
+        self._payload = payload
+
+    def json(self):
+        return self._payload
+
+
+class Stats:
+    def increment_captcha_decryptions_automatic(self):
+        pass
+
+    def increment_failed_decryptions_automatic(self):
+        pass
+
+
+class AlFlareSolverrSessionTests(unittest.TestCase):
+    def test_fetch_via_flaresolverr_reuses_browser_session_forwards_headers_and_updates_user_agent(
+        self,
+    ):
+        shared_state = SharedState()
+        session = requests.Session()
+        payload = {
+            "status": "ok",
+            "solution": {
+                "status": 200,
+                "headers": {},
+                "response": '{"code":"success","content":[]}',
+                "cookies": [],
+                "userAgent": "browser-agent",
+            },
+        }
+
+        with (
+            patch.object(al_sessions, "is_flaresolverr_available", return_value=True),
+            patch.object(
+                al_sessions, "retrieve_and_validate_session", return_value=session
+            ),
+            patch.object(al_sessions, "_persist_session_to_db"),
+            patch.object(
+                al_sessions.requests,
+                "post",
+                return_value=FlareSolverrResponse(payload),
+            ) as post,
+        ):
+            result = al_sessions.fetch_via_flaresolverr(
+                shared_state,
+                "POST",
+                "https://www.source.invalid/ajax/captcha",
+                post_data={"response": "nocaptcha"},
+                timeout=10,
+                session_id="browser-session",
+                request_headers={"X-Requested-With": "XMLHttpRequest"},
+            )
+
+        self.assertEqual(200, result["status_code"])
+        self.assertEqual("browser-agent", session.headers["User-Agent"])
+        self.assertEqual("browser-session", post.call_args.kwargs["json"]["session"])
+        self.assertEqual(
+            {"X-Requested-With": "XMLHttpRequest"},
+            post.call_args.kwargs["json"]["headers"],
+        )
+
+    def test_al_download_reuses_flaresolverr_session_and_ajax_headers_for_captcha_flow(
+        self,
+    ):
+        shared_state = SharedState()
+        fetch_session_ids = []
+        request_headers = []
+        post_payloads = []
+        validate_calls = []
+
+        def fake_fetch(_shared_state, method, target_url, **kwargs):
+            fetch_session_ids.append(kwargs.get("session_id"))
+            request_headers.append(kwargs.get("request_headers"))
+            post_data = kwargs.get("post_data") or {}
+            post_payloads.append(post_data)
+            if method == "GET":
+                return {"status_code": 200, "text": "<html></html>", "json": None}
+            # Only the "nocaptcha" start request stays on the FlareSolverr browser.
+            return {
+                "status_code": 200,
+                "text": "{}",
+                "json": {
+                    "code": "error",
+                    "message": ["captcha_required"],
+                    "content": [],
+                },
+            }
+
+        def fake_requests_fetch(_shared_state, method, target_url, **kwargs):
+            # The CAPTCHA validation must run on the same requests.Session that
+            # solved the CAPTCHA, not the FlareSolverr browser.
+            validate_calls.append(
+                {
+                    "post_data": kwargs.get("post_data") or {},
+                    "request_headers": kwargs.get("request_headers"),
+                }
+            )
+            return FlareSolverrResponse(
+                {
+                    "code": "success",
+                    "message": "",
+                    "content": [{"hoster": "Mirror", "cnl": {}}],
+                }
+            )
+
+        with (
+            patch(
+                "quasarr.downloads.sources.al.is_flaresolverr_available",
+                return_value=True,
+            ),
+            patch(
+                "quasarr.downloads.sources.al.retrieve_and_validate_session",
+                return_value=requests.Session(),
+            ),
+            patch(
+                "quasarr.downloads.sources.al.flaresolverr_create_session",
+                return_value="browser-session",
+            ),
+            patch(
+                "quasarr.downloads.sources.al.flaresolverr_destroy_session"
+            ) as destroy_session,
+            patch("quasarr.downloads.sources.al.fetch_via_flaresolverr", fake_fetch),
+            patch(
+                "quasarr.downloads.sources.al.fetch_via_requests_session",
+                fake_requests_fetch,
+            ),
+            patch(
+                "quasarr.downloads.sources.al._check_release",
+                return_value=("Example.Release", 1),
+            ),
+            patch("quasarr.downloads.sources.al._extract_episode", return_value=None),
+            patch(
+                "quasarr.downloads.sources.al.solve_captcha",
+                return_value={"response": "1", "captcha_id": "captcha-id"},
+            ) as solve_captcha,
+            patch(
+                "quasarr.downloads.sources.al.decrypt_content",
+                return_value=["https://files.invalid/download"],
+            ),
+            patch("quasarr.downloads.sources.al.StatsHelper", return_value=Stats()),
+        ):
+            result = Source().get_download_links(
+                shared_state,
+                "https://www.source.invalid/media/example",
+                [],
+                "Example.Release",
+                "1",
+            )
+
+        self.assertEqual(
+            {
+                "links": [["https://files.invalid/download", "files"]],
+                "password": "www.source.invalid",
+                "title": "Example.Release",
+            },
+            result,
+        )
+        self.assertEqual(
+            ["browser-session", "browser-session"],
+            fetch_session_ids,
+        )
+        self.assertIsNone(request_headers[0])
+        for headers in request_headers[1:]:
+            self.assertEqual(
+                "XMLHttpRequest",
+                headers.get("X-Requested-With"),
+            )
+            self.assertEqual(
+                "application/x-www-form-urlencoded; charset=UTF-8",
+                headers.get("Content-Type"),
+            )
+            self.assertNotIn("Origin", headers)
+            self.assertNotIn("Referer", headers)
+        self.assertEqual(
+            "XMLHttpRequest",
+            solve_captcha.call_args.kwargs["request_headers"].get("X-Requested-With"),
+        )
+        self.assertEqual(
+            "https://www.source.invalid",
+            solve_captcha.call_args.kwargs["request_headers"].get("Origin"),
+        )
+        self.assertEqual(
+            "https://www.source.invalid/media/example",
+            solve_captcha.call_args.kwargs["request_headers"].get("Referer"),
+        )
+        self.assertEqual(
+            "browser-session", solve_captcha.call_args.kwargs["session_id"]
+        )
+        # The validation runs once, on the requests.Session, carrying the solved
+        # CAPTCHA fields and the AJAX headers (not the FlareSolverr browser).
+        self.assertEqual(1, len(validate_calls))
+        validate_payload = validate_calls[0]["post_data"]
+        self.assertEqual("captcha", validate_payload["response"])
+        self.assertEqual(0, validate_payload["captcha-idhf"])
+        self.assertEqual("captcha-id", validate_payload["captcha-hf"])
+        self.assertEqual(
+            "XMLHttpRequest",
+            validate_calls[0]["request_headers"].get("X-Requested-With"),
+        )
+        destroy_session.assert_called_once_with(shared_state, "browser-session")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/uv.lock
+++ b/uv.lock
@@ -193,11 +193,11 @@ wheels = [
 
 [[package]]
 name = "filelock"
-version = "3.29.0"
+version = "3.29.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/b5/fe/997687a931ab51049acce6fa1f23e8f01216374ea81374ddee763c493db5/filelock-3.29.0.tar.gz", hash = "sha256:69974355e960702e789734cb4871f884ea6fe50bd8404051a3530bc07809cf90", size = 57571, upload-time = "2026-04-19T15:39:10.068Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/1f/f9/f38573ed5844586db374d085911740a501ccfa373b455fc9413f09f85237/filelock-3.29.1.tar.gz", hash = "sha256:d97e6b1b9757569626c58caa07dc4beb1613f4a2938b1e8cc81afca398906c9e", size = 59335, upload-time = "2026-06-03T15:19:04.053Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/81/47/dd9a212ef6e343a6857485ffe25bba537304f1913bdbed446a23f7f592e1/filelock-3.29.0-py3-none-any.whl", hash = "sha256:96f5f6344709aa1572bbf631c640e4ebeeb519e08da902c39a001882f30ac258", size = 39812, upload-time = "2026-04-19T15:39:08.752Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/a0/614c5fe402fd88951df45f4dda2fa3b4e17a99ecd92340771929169b3b95/filelock-3.29.1-py3-none-any.whl", hash = "sha256:85199dfd706869641b72b2e8955d5416a4b2b7dc4b0e8e6d97b4cc1299a6983b", size = 40750, upload-time = "2026-06-03T15:19:02.959Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What

Fixes #382 — AL CAPTCHA fails with `noadblock` even when the IP is not banned.

## Root cause

AL binds a solved CAPTCHA to the HTTP client that solved it. The flow fetched CAPTCHA icons and submitted the selection on `/files/captcha` via the `requests.Session`, but ran the final `/ajax/captcha` validation on the **FlareSolverr browser session** — a different client. AL saw a mismatch and rejected every solution with `The captcha ID was invalid`, surfacing to users as the `noadblock` retry loop and "Could not find matching source", even when the icon was picked correctly.

## Fix

Run the whole CAPTCHA solve **and** the final validation on one `requests.Session`. Only the details page and the initial `nocaptcha` arming request stay on the FlareSolverr browser session. The requests session also adopts FlareSolverr's User-Agent and sends browser-style AJAX headers so it stays browser-consistent.

## Verification

| Release | Path | Result |
|---|---|---|
| Slime S4E5 (the issue release) | no-CAPTCHA | 4 links ✓ |
| Yozakura S2 (home feed) | no-CAPTCHA | 16 links ✓ |
| Mahou no Shimai (home feed) | no-CAPTCHA | 16 links ✓ |
| Gantz (fresh IP) | CAPTCHA solved attempt 1 | 52 links ✓ |

71 unit tests pass, ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)