### PR TITLE
fix: update DT selectors for site redesign

### DIFF
--- a/quasarr/downloads/sources/dt.py
+++ b/quasarr/downloads/sources/dt.py
@@ -41,7 +41,7 @@ class Source(AbstractDownloadSource):
                 )
                 return None
 
-            body = article.find("div", class_="card-body")
+            body = article.find("div", class_="full-story-body")
             if not body:
                 info(f"Could not find download section for {title}")
                 mark_hostname_issue(

--- a/quasarr/providers/version.py
+++ b/quasarr/providers/version.py
@@ -5,7 +5,7 @@
 import re
 import sys
 
-__version__ = "4.5.5"
+__version__ = "4.5.6"
 
 
 def get_version():

--- a/quasarr/search/sources/dt.py
+++ b/quasarr/search/sources/dt.py
@@ -78,9 +78,10 @@ class Source(AbstractSearchSource):
 
             for article in feed.find_all("article"):
                 try:
-                    link_tag = article.select_one("h4.font-weight-bold a")
+                    link_tag = article.select_one("h1.dt-flexible-title a")
                     if not link_tag:
-                        warn(f"Link tag not found in article: {article}")
+                        # ad/promo articles lack a release title link; skip quietly
+                        debug(f"Link tag not found in article: {article}")
                         continue
 
                     source = link_tag["href"]
@@ -101,7 +102,9 @@ class Source(AbstractSearchSource):
                     except:
                         imdb_id = None
 
-                    body_text = article.find("div", class_="card-body").get_text(" ")
+                    body_text = article.find("div", class_="dt-text-clamp").get_text(
+                        " "
+                    )
                     size_match = re.search(
                         r"(\d+(?:\.\d+)?\s*(?:GB|MB|KB|TB))", body_text, re.IGNORECASE
                     )
@@ -230,7 +233,9 @@ class Source(AbstractSearchSource):
 
             for article in page.find_all("article"):
                 try:
-                    link_tag = article.select_one("h4.font-weight-bold a")
+                    # search-result articles use h1.font-weight-bold, while
+                    # the feed listing uses h1.dt-flexible-title
+                    link_tag = article.select_one("h1.font-weight-bold a")
                     if not link_tag:
                         debug(f"No title link in search-article: {article}")
                         continue
@@ -257,7 +262,9 @@ class Source(AbstractSearchSource):
                     except:
                         imdb_id = None
 
-                    body_text = article.find("div", class_="card-body").get_text(" ")
+                    body_text = article.find("div", class_="dt-text-clamp").get_text(
+                        " "
+                    )
                     m = re.search(
                         r"(\d+(?:\.\d+)?\s*(?:GB|MB|KB|TB))", body_text, re.IGNORECASE
                     )
@@ -329,13 +336,12 @@ def _extract_size(text):
 
 
 def _parse_published_datetime(article):
-    date_box = article.find("div", class_="mr-2 shadow-sm1 text-center")
-    mon = date_box.find("small").text.strip()
-    day = date_box.find("h4").text.strip()
-    year = date_box.find("h6").text.strip()
+    mon = article.select_one("small.dt-fs-11").text.strip()
+    day = article.find("h4", class_="m-0").text.strip()
+    year = article.find("h6", class_="m-0").text.strip()
     month_num = datetime.datetime.strptime(mon, "%b").month
 
-    time_icon = article.select_one("i.fa-clock-o")
+    time_icon = article.select_one("i.bi-clock")
     if time_icon:
         # its parent <span> contains e.g. "19:12"
         raw = time_icon.parent.get_text(strip=True)


### PR DESCRIPTION
## Problem

DT redesigned its site HTML, breaking every BeautifulSoup selector in both the search and download paths:

- **Feed search** logged `Link tag not found in article` for every release and returned **zero** results.
- **Download handler** could no longer locate the link section and failed (quietly, via `info` + `mark_hostname_issue`).

## Fix

Selectors updated against **real captured traffic** — movie feed, show feed, the search-result page, and release detail pages. The feed listing and the search-result listing use **different** title markup, so they need different selectors:

| Field | Old | New |
|-------|-----|-----|
| Feed title link | `h4.font-weight-bold a` | `h1.dt-flexible-title a` |
| Search title link | `h4.font-weight-bold a` | `h1.font-weight-bold a` |
| Listing body (size) | `div.card-body` | `div.dt-text-clamp` |
| Date box | `div.mr-2 shadow-sm1 text-center` → `small`/`h4`/`h6` | `small.dt-fs-11` / `h4.m-0` / `h6.m-0` |
| Publish time | `i.fa-clock-o` | `i.bi-clock` |
| Detail download section | `div.card-body` | `div.full-story-body` |

Missing-title in `feed()` downgraded `warn` → `debug`: the new layout's ad/promo articles (e.g. LinkSnappy) legitimately lack a release title link and are expected skips — matching existing `search()` behaviour.

## Verification

End-to-end against live captures:

- **Feed**: show 10/10, movie 9/10 parsed (skips are size-less, server-clamped descriptions — pre-existing quirk, not a regression).
- **Search**: old titles now resolve (Avatar 2009, The Matrix, Gladiator, Dune, Breaking Bad, The Office, Top Gun, …).
- **Downloads**: 10/10 random feed releases (all 4 categories) and 7/7 random search releases return hoster links; `imdb.com` and the linksnappy `?ref=` ad are correctly dropped; mirror-filter cases behave correctly.

### Known limitation (pre-existing, not introduced here)

Releases whose listing description is long enough to be server-truncated before the mediainfo line expose **no size** in the listing HTML, so both feed and search drop them (size is required from the listing). Affects some long-plot catalogue titles (e.g. a lone *Titanic (1997)* entry). The size is only available on the detail page; recovering it would require an extra fetch and is out of scope for this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)