### PR TITLE
fix: rank online WX containers above direct links

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 # Project by https://github.com/rix1337
 
-.claude/*.local.json
+.claude/
 
 # Python
 *.pyc

--- a/docs/Mirror-Selection.md
+++ b/docs/Mirror-Selection.md
@@ -1,0 +1,72 @@
+# Mirror Selection
+
+How Quasarr decides which mirror / link set to hand to JDownloader when a
+release exposes more than one. This is a product-wide policy; per-source
+specifics live in the matching `sources/*.md` file.
+
+## The flow
+
+Quasarr makes the best possible decision from the signals a source provides,
+hands the result to JDownloader, and stops there:
+
+```
+Quasarr picks the best link set from the source's own signals
+  (never by inspecting the direct links themselves)
+    -> JDownloader resolves and downloads
+      -> if it fails, Quasarr reports the failure
+        -> Radarr/Sonarr decide, usually blacklist + next release
+```
+
+Resolving and verifying a hoster link is JDownloader's job, not Quasarr's.
+
+## Scope boundary (hard rule)
+
+Quasarr does **not** verify whether a direct hoster link is online. File
+availability is JDownloader's responsibility, a dedicated and paid operation
+with hoster-specific handling Quasarr cannot and should not replicate. Quasarr
+only *selects* links from the metadata a source already provides; it never
+fetches a hoster URL to probe its liveness.
+
+A link that turns out to be dead is therefore not a selection bug. It is
+absorbed by the flow above: JDownloader marks it offline, Quasarr surfaces the
+failure, and Radarr/Sonarr blacklist the release and pick the next one.
+
+## Selection priority
+
+Rank by the link set whose online status the source actually certifies. A
+source's status signal (for example WX's badges in `options.check`) describes
+the crypted **container**, not the separately uploaded direct links, so a
+certified-online container outranks a direct link the signal does not describe.
+General order:
+
+1. **Online-certified crypted container, cheapest crypter first.** hide resolves
+   automatically without a CAPTCHA; filecrypt is handed to JDownloader and may
+   cost a CAPTCHA. So: green hide container, then green filecrypt container.
+2. **Direct links carrying a green signal.** Best effort only: the green signal
+   really measures the container, so for direct links it is a guess.
+3. **First offline-flagged mirror, as a last resort,** so the release is still
+   attempted and fails cleanly into the blacklist-and-retry path.
+
+If a source exposes no online signal at all, fall back to newest mirror first
+(when recency is known), then the first/arbitrary mirror.
+
+Never add a tier that fetches a direct hoster URL to test it. That is out of
+scope at every level of this list.
+
+## Why containers rank above direct links
+
+The status signal certifies the container, not the direct links. Measured on WX,
+the direct links agree with their container about 95% of the time, but roughly
+5% are dead under a green badge because the direct file is a separate upload
+that rotted independently of the still-online container (see
+[WX](sources/WX.md)).
+
+Choosing the certified container instead trades CAPTCHA-free convenience on
+filecrypt mirrors for links that are actually online. That trade is deliberate:
+an online download that costs a CAPTCHA beats a fast download that is dead. hide
+containers cost nothing because they auto-resolve, so they always come first.
+
+The remaining all-offline case is left to the flow above. Manually clicking a
+still-online link in a browser will always beat any automated choice for a
+single release; that is not a signal Quasarr can generalize from, and it is not
+a reason to start probing links.

--- a/docs/README.md
+++ b/docs/README.md
@@ -28,6 +28,10 @@ Read this when preparing commits or pull requests. It documents the preferred co
 
 Read this for rules around `.env` handling, credentials, tokens, runtime configuration, and the strict rule that source hostnames must never be committed to tracked files.
 
+### [Mirror Selection](Mirror-Selection.md)
+
+Read this before changing how a download source picks between multiple mirrors or link sets. It defines the selection priority (crypter online signal, then newest mirror, then first/arbitrary), the hard rule that Quasarr never probes direct-link liveness (that is JDownloader's job), and why the policy is deliberately not changed.
+
 ### [Sources](sources/README.md)
 
 Read this when working on a specific source integration. The `sources/` folder contains per-source documentation covering API behavior, supported categories, hostname setup, and source-specific details.

--- a/docs/sources/WX.md
+++ b/docs/sources/WX.md
@@ -40,3 +40,15 @@ prove the direct link is online; preferring the certified container avoids the
 dead-direct-link case at the cost of a CAPTCHA on filecrypt mirrors. Quasarr never
 probes direct-link liveness (JDownloader's job). See
 [Mirror Selection](../Mirror-Selection.md) for the rationale.
+
+### filecrypt to hide.cx twin (user_id)
+
+For uploads from the WX user ids in `HIDE_CX_MIRROR_USER_IDS`, the same container
+is also published on hide.cx under the same id. Their `filecrypt.cc` containers
+are rewritten to the `hide.cx/fc` twin so they auto-resolve via `hide.py` without
+a CAPTCHA (tier 1) instead of going to the filecrypt/SponsorsHelper path. This is
+not a guess: it mirrors the WX frontend exactly, which gates the identical
+`filecrypt.cc -> hide.cx/fc` rewrite on `[4].includes(mirror.user)` (the release
+`user_id`). Uploads from other ids are left as filecrypt. If hide.cx happens not
+to have a given container, `hide.py` returns nothing and the normal
+auto-decrypt to SponsorsHelper fallback applies.

--- a/docs/sources/WX.md
+++ b/docs/sources/WX.md
@@ -22,3 +22,21 @@ Per-source notes for the `WX` integration. For conventions, see `docs/sources/RE
 - Search filters API results by an internal type token (movie / series / anime) to match the requested category.
 - Releases are deduplicated by full title; mirrors come from the per-release block.
 - IMDb mismatches between the query and the release are dropped; the release's own IMDb identifier is preferred when the query did not supply one.
+
+## Mirror selection
+
+Each mirror exposes direct hoster URLs (`links`), crypted containers
+(`crypted_links`, filecrypt or hide) and per-hoster status badges
+(`options.check`). The badge certifies the container, not the separately
+uploaded direct links, so containers rank above direct links:
+
+1. green hide.cx container (resolved downstream by `hide.py`, no CAPTCHA)
+2. green filecrypt container (handed to JDownloader, may need a CAPTCHA)
+3. green direct links (best effort; the badge does not measure them)
+4. first offline-flagged mirror as a last resort
+
+The `links` set and the container are separate uploads, so a green badge does not
+prove the direct link is online; preferring the certified container avoids the
+dead-direct-link case at the cost of a CAPTCHA on filecrypt mirrors. Quasarr never
+probes direct-link liveness (JDownloader's job). See
+[Mirror Selection](../Mirror-Selection.md) for the rationale.

--- a/quasarr/downloads/sources/wx.py
+++ b/quasarr/downloads/sources/wx.py
@@ -173,10 +173,19 @@ class Source(AbstractDownloadSource):
                         fc_candidates.append([container_url, hoster, state_url])
                     # Other crypters are unsupported and ignored.
 
+                # Only containers that actually carry a status badge are
+                # eligible for the certified-online tiers. A container without a
+                # badge is not certified online (check_links_online_status would
+                # treat a missing status URL as online), so it must not outrank a
+                # badge-green direct link or another mirror; it stays a no-signal
+                # last resort (tier 4) instead.
+                hide_badged = [c for c in hide_candidates if c[2] is not None]
+                fc_badged = [c for c in fc_candidates if c[2] is not None]
+
                 # Tier 1 candidate: this mirror's online hide.cx containers.
                 online_hide = (
-                    check_links_online_status(hide_candidates, shared_state)
-                    if hide_candidates
+                    check_links_online_status(hide_badged, shared_state)
+                    if hide_badged
                     else []
                 )
                 if online_hide and (
@@ -186,8 +195,8 @@ class Source(AbstractDownloadSource):
 
                 # Tier 2 candidate: this mirror's online filecrypt containers.
                 online_fc = (
-                    check_links_online_status(fc_candidates, shared_state)
-                    if fc_candidates
+                    check_links_online_status(fc_badged, shared_state)
+                    if fc_badged
                     else []
                 )
                 if online_fc and (best_fc is None or len(online_fc) > best_fc[0]):

--- a/quasarr/downloads/sources/wx.py
+++ b/quasarr/downloads/sources/wx.py
@@ -12,6 +12,14 @@ from quasarr.providers.hostname_issues import mark_hostname_issue
 from quasarr.providers.log import debug, info
 from quasarr.providers.utils import check_links_online_status
 
+# WX publishes filecrypt and hide.cx as mirror crypters of the same container
+# id. Uploads from these WX user ids are always also published on hide.cx, so
+# their filecrypt.cc containers can be rewritten to the hide.cx twin and resolved
+# automatically via hide.py without a CAPTCHA. This mirrors the WX frontend
+# exactly: app.js gates the identical `filecrypt.cc -> hide.cx/fc` rewrite on
+# `[4].includes(mirror.user)`, where `mirror.user` is the release `user_id`.
+HIDE_CX_MIRROR_USER_IDS = {4}
+
 
 def _collect_online_direct_links(release, mirrors, shared_state):
     """
@@ -158,6 +166,12 @@ class Source(AbstractDownloadSource):
             for release in matching_releases:
                 crypted_links = release.get("crypted_links", {}) or {}
                 check_urls = release.get("options", {}).get("check", {}) or {}
+                # See HIDE_CX_MIRROR_USER_IDS: for these uploaders a filecrypt.cc
+                # container is also published on hide.cx under the same id, so we
+                # use the hide twin (auto-resolved, no CAPTCHA) - exactly what the
+                # WX frontend does for `mirror.user`.
+                user_id = release.get("user_id")
+                mirror_to_hide = user_id in HIDE_CX_MIRROR_USER_IDS
 
                 hide_candidates = []  # [container_url, hoster, status_url]
                 fc_candidates = []
@@ -167,6 +181,13 @@ class Source(AbstractDownloadSource):
                     ):
                         continue
                     state_url = check_urls.get(hoster)
+                    if mirror_to_hide and "filecrypt.cc" in container_url.lower():
+                        container_url = re.sub(
+                            r"filecrypt\.cc",
+                            "hide.cx/fc",
+                            container_url,
+                            flags=re.IGNORECASE,
+                        )
                     if re.search(r"hide\.", container_url, re.IGNORECASE):
                         hide_candidates.append([container_url, hoster, state_url])
                     elif re.search(r"filecrypt\.", container_url, re.IGNORECASE):

--- a/quasarr/downloads/sources/wx.py
+++ b/quasarr/downloads/sources/wx.py
@@ -244,11 +244,16 @@ class Source(AbstractDownloadSource):
                             continue
                         if not isinstance(urls, list):
                             urls = [urls]
-                        for u in urls:
-                            if isinstance(u, str) and u.strip():
-                                red_direct = [u.strip(), hoster]
-                                break
-                        if red_direct:
+                        # Keep ALL parts of this hoster: a WX direct hoster can
+                        # be a multipart archive, so a single URL is an
+                        # incomplete mirror that JDownloader cannot finish.
+                        parts = [
+                            [u.strip(), hoster]
+                            for u in urls
+                            if isinstance(u, str) and u.strip()
+                        ]
+                        if parts:
+                            red_direct = parts
                             break
 
             # Tier 1: green hide.cx containers from the best single mirror.
@@ -279,13 +284,20 @@ class Source(AbstractDownloadSource):
             # mirror to JDownloader as a last resort (hide > filecrypt > direct)
             # so the release is still attempted and, if dead, fails cleanly into
             # the Radarr/Sonarr blacklist-and-retry path.
-            red_first = red_hide or red_fc or red_direct
-            if red_first:
+            # Containers are complete on their own (one URL); a direct mirror
+            # keeps all its parts.
+            if red_hide:
+                red_links = [red_hide]
+            elif red_fc:
+                red_links = [red_fc]
+            else:
+                red_links = red_direct
+            if red_links:
                 debug(
                     "Tier 4: no online signal; handing first offline-flagged "
                     "mirror to JDownloader as last resort"
                 )
-                return {"links": [[red_first[0], red_first[1]]]}
+                return {"links": red_links}
 
             info(f"No links found for: {title}")
             return {"links": []}

--- a/quasarr/downloads/sources/wx.py
+++ b/quasarr/downloads/sources/wx.py
@@ -62,10 +62,15 @@ class Source(AbstractDownloadSource):
 
     def get_download_links(self, shared_state, url, mirrors, title, password):
         """
-        WX source handler - Grabs download links from API based on title.
-        Finds the best mirror (M1, M2, M3...) by checking online status.
-        Returns all online links from the first complete mirror, or the best partial mirror.
-        Prefers hide.cx links over other crypters (filecrypt, etc.) when online counts are equal.
+        WX source handler. Picks the mirror/link set with the best
+        source-provided online signal and hands it to JDownloader; it never
+        probes a direct hoster link itself (liveness is JDownloader's job).
+
+        Priority (see docs/Mirror-Selection.md):
+          1. green hide.cx container   (resolved downstream by hide.py, no CAPTCHA)
+          2. green filecrypt container (handed to JDownloader, may need CAPTCHA)
+          3. green direct links        (no badge of their own; best effort)
+          4. first offline-flagged mirror as a last resort
         """
         host = shared_state.values["config"]("Hostnames").get(Source.initials)
 
@@ -125,126 +130,134 @@ class Source(AbstractDownloadSource):
 
             debug(f"Found {len(matching_releases)} mirror(s) for: {title}")
 
-            # PRIORITY: WX exposes ready-to-use direct download links in the
-            # 'links' field for every release. They need no crypter and no
-            # CAPTCHA, so prefer them over the filecrypt/hide containers in
-            # 'crypted_links' (which can break on CAPTCHA, IP bans or FSG).
-            best_direct = None  # (online_hoster_count, links)
-            for idx, release in enumerate(matching_releases):
-                count, direct_links = _collect_online_direct_links(
-                    release, mirrors, shared_state
-                )
-                if direct_links:
-                    debug(f"M{idx + 1} direct links: {count} online hoster(s)")
-                    if best_direct is None or count > best_direct[0]:
-                        best_direct = (count, direct_links)
+            # SELECTION POLICY (see docs/Mirror-Selection.md):
+            # Quasarr picks the link set with the best *source-provided* online
+            # signal and hands it to JDownloader. It never probes a direct
+            # hoster link itself - liveness is JDownloader's job. WX's status
+            # badge (options.check) certifies the crypted *container*, not the
+            # separate direct 'links' upload, so containers rank above direct
+            # links. A dead pick is expected to fail in JDownloader, which
+            # Quasarr reports so Radarr/Sonarr can blacklist and try the next
+            # release.
+            #
+            # Each mirror (M1, M2, ...) is a distinct upload of the release, so
+            # link sets are NEVER merged across mirrors - that would enqueue
+            # duplicate copies of the same release in JDownloader. We evaluate
+            # mirror by mirror and return a single mirror's set. Within that one
+            # mirror, every online hoster is kept on purpose (redundant hoster
+            # choices for the same files; the automation submits them and the
+            # manual flow lets the user pick one).
 
-            if best_direct and best_direct[1]:
-                debug(
-                    f"Using {len(best_direct[1])} direct download link(s) "
-                    f"from best mirror ({best_direct[0]} online hoster(s))"
-                )
-                return {"links": best_direct[1]}
+            # Best single mirror per tier: (online_count, links).
+            best_hide = None
+            best_fc = None
+            best_direct = None
+            # Last-resort offline pick, hide > filecrypt > direct preference.
+            red_hide = red_fc = red_direct = None
 
-            # FALLBACK: no usable direct links → resolve crypted containers.
-            # Evaluate each mirror and find the best one
-            # Track: (online_count, is_hide, online_links)
-            best_mirror = None  # (online_count, is_hide, online_links)
+            for release in matching_releases:
+                crypted_links = release.get("crypted_links", {}) or {}
+                check_urls = release.get("options", {}).get("check", {}) or {}
 
-            for idx, release in enumerate(matching_releases):
-                crypted_links = release.get("crypted_links", {})
-                check_urls = release.get("options", {}).get("check", {})
-
-                if not crypted_links:
-                    continue
-
-                # Separate hide.cx links from other crypters
-                hide_links = []
-                other_links = []
-
+                hide_candidates = []  # [container_url, hoster, status_url]
+                fc_candidates = []
                 for hoster, container_url in crypted_links.items():
-                    # Filter by requested mirrors if specified
                     if mirrors and not any(
                         m.lower() in hoster.lower() for m in mirrors
                     ):
                         continue
-
                     state_url = check_urls.get(hoster)
                     if re.search(r"hide\.", container_url, re.IGNORECASE):
-                        hide_links.append([container_url, hoster, state_url])
+                        hide_candidates.append([container_url, hoster, state_url])
                     elif re.search(r"filecrypt\.", container_url, re.IGNORECASE):
-                        other_links.append([container_url, hoster, state_url])
-                    # Skip other crypters we don't support
+                        fc_candidates.append([container_url, hoster, state_url])
+                    # Other crypters are unsupported and ignored.
 
-                # Check hide.cx links first (preferred)
-                hide_online = 0
-                online_hide = []
-                if hide_links:
-                    online_hide = check_links_online_status(hide_links, shared_state)
-                    hide_total = len(hide_links)
-                    hide_online = len(online_hide)
-
-                    debug(f"M{idx + 1} hide.cx: {hide_online}/{hide_total} online")
-
-                    # If all hide.cx links are online, use this mirror immediately
-                    if hide_online == hide_total and hide_online > 0:
-                        debug(
-                            f"M{idx + 1} is complete (all {hide_online} hide.cx links online), using this mirror"
-                        )
-                        return {"links": online_hide}
-
-                # Check other crypters (filecrypt, etc.) - no early return, always check all mirrors for hide.cx first
-                other_online = 0
-                online_other = []
-                if other_links:
-                    online_other = check_links_online_status(other_links, shared_state)
-                    other_total = len(other_links)
-                    other_online = len(online_other)
-
-                    debug(
-                        f"M{idx + 1} other crypters: {other_online}/{other_total} online"
-                    )
-
-                # Determine best option for this mirror (prefer hide.cx on ties)
-                mirror_links = None
-                mirror_count = 0
-                mirror_is_hide = False
-
-                if hide_online > 0 and hide_online >= other_online:
-                    # hide.cx wins (more links or tie)
-                    mirror_links = online_hide
-                    mirror_count = hide_online
-                    mirror_is_hide = True
-                elif other_online > hide_online:
-                    # other crypter has more online links
-                    mirror_links = online_other
-                    mirror_count = other_online
-                    mirror_is_hide = False
-
-                # Update best_mirror if this mirror is better
-                # Priority: 1) more online links, 2) hide.cx preference on ties
-                if mirror_links:
-                    if best_mirror is None:
-                        best_mirror = (mirror_count, mirror_is_hide, mirror_links)
-                    elif mirror_count > best_mirror[0]:
-                        best_mirror = (mirror_count, mirror_is_hide, mirror_links)
-                    elif (
-                        mirror_count == best_mirror[0]
-                        and mirror_is_hide
-                        and not best_mirror[1]
-                    ):
-                        # Same count but this is hide.cx and current best is not
-                        best_mirror = (mirror_count, mirror_is_hide, mirror_links)
-
-            # No complete mirror found, return best partial mirror
-            if best_mirror and best_mirror[2]:
-                crypter_type = "hide.cx" if best_mirror[1] else "other crypter"
-                debug(
-                    f"No complete mirror, using best partial with {best_mirror[0]} online {crypter_type} link(s)"
+                # Tier 1 candidate: this mirror's online hide.cx containers.
+                online_hide = (
+                    check_links_online_status(hide_candidates, shared_state)
+                    if hide_candidates
+                    else []
                 )
-                return {"links": best_mirror[2]}
+                if online_hide and (
+                    best_hide is None or len(online_hide) > best_hide[0]
+                ):
+                    best_hide = (len(online_hide), online_hide)
 
-            info(f"No online links found for: {title}")
+                # Tier 2 candidate: this mirror's online filecrypt containers.
+                online_fc = (
+                    check_links_online_status(fc_candidates, shared_state)
+                    if fc_candidates
+                    else []
+                )
+                if online_fc and (best_fc is None or len(online_fc) > best_fc[0]):
+                    best_fc = (len(online_fc), online_fc)
+
+                # Tier 3 candidate: this mirror's online direct links.
+                count, direct_links = _collect_online_direct_links(
+                    release, mirrors, shared_state
+                )
+                if direct_links and (best_direct is None or count > best_direct[0]):
+                    best_direct = (count, direct_links)
+
+                # Tier 4 fallbacks: first offline-flagged option of each kind.
+                if red_hide is None and hide_candidates:
+                    red_hide = [hide_candidates[0][0], hide_candidates[0][1]]
+                if red_fc is None and fc_candidates:
+                    red_fc = [fc_candidates[0][0], fc_candidates[0][1]]
+                if red_direct is None:
+                    links_field = release.get("links", {}) or {}
+                    for hoster, urls in links_field.items():
+                        if mirrors and not any(
+                            m.lower() in hoster.lower() for m in mirrors
+                        ):
+                            continue
+                        if not isinstance(urls, list):
+                            urls = [urls]
+                        for u in urls:
+                            if isinstance(u, str) and u.strip():
+                                red_direct = [u.strip(), hoster]
+                                break
+                        if red_direct:
+                            break
+
+            # Tier 1: green hide.cx containers from the best single mirror.
+            if best_hide:
+                debug(
+                    f"Tier 1: {best_hide[0]} online hide.cx container(s) "
+                    f"- handing to JDownloader"
+                )
+                return {"links": best_hide[1]}
+
+            # Tier 2: green filecrypt containers from the best single mirror.
+            if best_fc:
+                debug(
+                    f"Tier 2: {best_fc[0]} online filecrypt container(s) "
+                    f"- handing to JDownloader"
+                )
+                return {"links": best_fc[1]}
+
+            # Tier 3: green direct links from the best single mirror.
+            if best_direct and best_direct[1]:
+                debug(
+                    f"Tier 3: {len(best_direct[1])} direct link(s) from best "
+                    f"mirror ({best_direct[0]} online hoster(s)) - handing to JDownloader"
+                )
+                return {"links": best_direct[1]}
+
+            # Tier 4: no online signal anywhere. Hand the first offline-flagged
+            # mirror to JDownloader as a last resort (hide > filecrypt > direct)
+            # so the release is still attempted and, if dead, fails cleanly into
+            # the Radarr/Sonarr blacklist-and-retry path.
+            red_first = red_hide or red_fc or red_direct
+            if red_first:
+                debug(
+                    "Tier 4: no online signal; handing first offline-flagged "
+                    "mirror to JDownloader as last resort"
+                )
+                return {"links": [[red_first[0], red_first[1]]]}
+
+            info(f"No links found for: {title}")
             return {"links": []}
 
         except Exception as e:

--- a/quasarr/providers/version.py
+++ b/quasarr/providers/version.py
@@ -5,7 +5,7 @@
 import re
 import sys
 
-__version__ = "4.5.6"
+__version__ = "4.5.7"
 
 
 def get_version():

--- a/quasarr/search/sources/dt.py
+++ b/quasarr/search/sources/dt.py
@@ -109,7 +109,7 @@ class Source(AbstractSearchSource):
                         r"(\d+(?:\.\d+)?\s*(?:GB|MB|KB|TB))", body_text, re.IGNORECASE
                     )
                     if not size_match:
-                        warn(f"Size not found in article for {title_raw}")
+                        debug(f"Size not found in article for {title_raw}")
                         continue
                     size_info = size_match.group(1).strip()
                     size_item = _extract_size(size_info)

--- a/tests/test_wx_direct_links.py
+++ b/tests/test_wx_direct_links.py
@@ -104,9 +104,19 @@ class WxDirectLinksTests(unittest.TestCase):
                     "ddownload.com": "https://filecrypt.cc/Container/AAA.html",
                     "rapidgator.net": "https://filecrypt.cc/Container/BBB.html",
                 },
+                check={
+                    "ddownload.com": "https://filecrypt.cc/Stat/A.png",
+                    "rapidgator.net": "https://filecrypt.cc/Stat/B.png",
+                },
             )
         ]
-        result = self._run(releases)
+        result = self._run(
+            releases,
+            online_badge_urls={
+                "https://filecrypt.cc/Stat/A.png",
+                "https://filecrypt.cc/Stat/B.png",
+            },
+        )
         urls = sorted(link[0] for link in result["links"])
         # The filecrypt containers are handed over; no direct link leaks through.
         self.assertEqual(
@@ -131,9 +141,19 @@ class WxDirectLinksTests(unittest.TestCase):
                     "ddownload.com": "https://hide.cx/fc/Container/HIDE.html",
                     "rapidgator.net": "https://filecrypt.cc/Container/BBB.html",
                 },
+                check={
+                    "ddownload.com": "https://filecrypt.cc/Stat/H.png",
+                    "rapidgator.net": "https://filecrypt.cc/Stat/F.png",
+                },
             )
         ]
-        result = self._run(releases)
+        result = self._run(
+            releases,
+            online_badge_urls={
+                "https://filecrypt.cc/Stat/H.png",
+                "https://filecrypt.cc/Stat/F.png",
+            },
+        )
         urls = [link[0] for link in result["links"]]
         self.assertEqual(urls, ["https://hide.cx/fc/Container/HIDE.html"])
 
@@ -145,13 +165,35 @@ class WxDirectLinksTests(unittest.TestCase):
                 self.TITLE,
                 {"rapidgator.net": ["https://rapidgator.net/file/x"]},
                 {"rapidgator.net": "https://filecrypt.cc/Container/ZZZ.html"},
+                check={"rapidgator.net": "https://filecrypt.cc/Stat/Z.png"},
             )
         ]
-        result = self._run(releases)
+        result = self._run(
+            releases,
+            online_badge_urls={"https://filecrypt.cc/Stat/Z.png"},
+        )
         self.assertEqual(
             [link[0] for link in result["links"]],
             ["https://filecrypt.cc/Container/ZZZ.html"],
         )
+
+    def test_unchecked_container_does_not_preempt_green_direct(self):
+        # A container without a status badge is not certified online and must
+        # not jump ahead of a badge-green direct link.
+        releases = [
+            _release(
+                self.TITLE,
+                {"ddownload.com": ["https://ddownload.com/live"]},
+                {"rapidgator.net": "https://hide.cx/container/NOBADGE"},
+                check={"ddownload.com": "https://filecrypt.cc/Stat/GREEN.png"},
+            )
+        ]
+        result = self._run(
+            releases,
+            online_badge_urls={"https://filecrypt.cc/Stat/GREEN.png"},
+        )
+        urls = [link[0] for link in result["links"]]
+        self.assertEqual(urls, ["https://ddownload.com/live"])
 
     def test_direct_links_used_when_all_containers_red(self):
         # Container badge is red, a direct-only hoster has a green badge: with no
@@ -322,15 +364,19 @@ class WxDirectLinksTests(unittest.TestCase):
         self.assertFalse(any("/m1" in u for u in urls))
 
     def test_falls_back_to_crypted_when_no_direct_links(self):
-        # Empty 'links' field → must fall back to the filecrypt container.
+        # Empty 'links' field → must use the online filecrypt container.
         releases = [
             _release(
                 self.TITLE,
                 {},
                 {"ddownload.com": "https://filecrypt.cc/Container/CCC.html"},
+                check={"ddownload.com": "https://filecrypt.cc/Stat/C.png"},
             )
         ]
-        result = self._run(releases)
+        result = self._run(
+            releases,
+            online_badge_urls={"https://filecrypt.cc/Stat/C.png"},
+        )
         urls = [link[0] for link in result["links"]]
         self.assertEqual(urls, ["https://filecrypt.cc/Container/CCC.html"])
 

--- a/tests/test_wx_direct_links.py
+++ b/tests/test_wx_direct_links.py
@@ -482,6 +482,30 @@ class WxDirectLinksTests(unittest.TestCase):
             ["https://hide.cx/container/A", "https://hide.cx/container/B"],
         )
 
+    def test_tier4_direct_fallback_keeps_all_parts(self):
+        # Last resort with only direct links and a red badge: a multipart hoster
+        # must hand over ALL parts, not just the first, or JDownloader cannot
+        # finish the release if the red badge was a false negative.
+        releases = [
+            _release(
+                self.TITLE,
+                {
+                    "ddownload.com": [
+                        "https://ddownload.com/p1",
+                        "https://ddownload.com/p2",
+                    ]
+                },
+                {},
+                check={"ddownload.com": "https://filecrypt.cc/Stat/RED.png"},
+            )
+        ]
+        result = self._run(releases, online_badge_urls=set())
+        urls = [link[0] for link in result["links"]]
+        self.assertEqual(
+            urls,
+            ["https://ddownload.com/p1", "https://ddownload.com/p2"],
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_wx_direct_links.py
+++ b/tests/test_wx_direct_links.py
@@ -31,12 +31,13 @@ def _api_payload(releases):
     return {"item": {"releases": releases}}
 
 
-def _release(fulltitle, links, crypted, check=None):
+def _release(fulltitle, links, crypted, check=None, user_id=None):
     return {
         "fulltitle": fulltitle,
         "links": links,
         "crypted_links": crypted,
         "options": {"check": check or {}},
+        "user_id": user_id,
     }
 
 
@@ -175,6 +176,49 @@ class WxDirectLinksTests(unittest.TestCase):
         self.assertEqual(
             [link[0] for link in result["links"]],
             ["https://filecrypt.cc/Container/ZZZ.html"],
+        )
+
+    def test_user_id_4_filecrypt_rewritten_to_hide(self):
+        # Uploads from user_id 4 mirror their filecrypt.cc container on hide.cx
+        # under the same id; the handler rewrites it to the hide twin (tier 1,
+        # auto-resolved) - mirroring the WX frontend's [4].includes(mirror.user).
+        releases = [
+            _release(
+                self.TITLE,
+                {},
+                {"ddownload.com": "https://filecrypt.cc/Container/AA.html"},
+                check={"ddownload.com": "https://filecrypt.cc/Stat/G.png"},
+                user_id=4,
+            )
+        ]
+        result = self._run(
+            releases,
+            online_badge_urls={"https://filecrypt.cc/Stat/G.png"},
+        )
+        self.assertEqual(
+            [link[0] for link in result["links"]],
+            ["https://hide.cx/fc/Container/AA.html"],
+        )
+
+    def test_other_user_id_filecrypt_not_rewritten(self):
+        # Uploads from other user ids are not mirrored on hide.cx, so the
+        # filecrypt container is kept (tier 2) and not rewritten.
+        releases = [
+            _release(
+                self.TITLE,
+                {},
+                {"ddownload.com": "https://filecrypt.cc/Container/AA.html"},
+                check={"ddownload.com": "https://filecrypt.cc/Stat/G.png"},
+                user_id=188,
+            )
+        ]
+        result = self._run(
+            releases,
+            online_badge_urls={"https://filecrypt.cc/Stat/G.png"},
+        )
+        self.assertEqual(
+            [link[0] for link in result["links"]],
+            ["https://filecrypt.cc/Container/AA.html"],
         )
 
     def test_unchecked_container_does_not_preempt_green_direct(self):

--- a/tests/test_wx_direct_links.py
+++ b/tests/test_wx_direct_links.py
@@ -87,7 +87,9 @@ class WxDirectLinksTests(unittest.TestCase):
                 SharedState(), self.URL, mirrors or [], self.TITLE, ""
             )
 
-    def test_prefers_direct_links_over_filecrypt(self):
+    def test_prefers_green_filecrypt_container_over_direct(self):
+        # The status badge certifies the container, not the separate direct
+        # upload, so an online filecrypt container outranks the direct links.
         releases = [
             _release(
                 self.TITLE,
@@ -105,23 +107,39 @@ class WxDirectLinksTests(unittest.TestCase):
             )
         ]
         result = self._run(releases)
-        urls = [link[0] for link in result["links"]]
-        # All direct hoster links returned; no filecrypt container leaks through.
+        urls = sorted(link[0] for link in result["links"])
+        # The filecrypt containers are handed over; no direct link leaks through.
         self.assertEqual(
-            sorted(urls),
+            urls,
             sorted(
                 [
-                    "https://ddownload.com/a",
-                    "https://ddownload.com/b",
-                    "https://rapidgator.net/file/c",
+                    "https://filecrypt.cc/Container/AAA.html",
+                    "https://filecrypt.cc/Container/BBB.html",
                 ]
             ),
         )
-        self.assertFalse(any("filecrypt" in u for u in urls))
+        self.assertFalse(any("ddownload" in u or "rapidgator" in u for u in urls))
 
-    def test_filecrypt_only_release_still_yields_direct_links(self):
-        # No hide.cx mirror anywhere; crypted is filecrypt-only. Direct links
-        # must still be used instead of failing into the CAPTCHA path.
+    def test_prefers_hide_container_over_filecrypt_and_direct(self):
+        # hide.cx resolves without a CAPTCHA, so a green hide container is the
+        # top tier, above filecrypt containers and direct links.
+        releases = [
+            _release(
+                self.TITLE,
+                {"ddownload.com": ["https://ddownload.com/a"]},
+                {
+                    "ddownload.com": "https://hide.cx/fc/Container/HIDE.html",
+                    "rapidgator.net": "https://filecrypt.cc/Container/BBB.html",
+                },
+            )
+        ]
+        result = self._run(releases)
+        urls = [link[0] for link in result["links"]]
+        self.assertEqual(urls, ["https://hide.cx/fc/Container/HIDE.html"])
+
+    def test_filecrypt_only_release_uses_container(self):
+        # No hide.cx mirror; the green filecrypt container is handed to
+        # JDownloader rather than the (badge-unverified) direct link.
         releases = [
             _release(
                 self.TITLE,
@@ -132,8 +150,51 @@ class WxDirectLinksTests(unittest.TestCase):
         result = self._run(releases)
         self.assertEqual(
             [link[0] for link in result["links"]],
-            ["https://rapidgator.net/file/x"],
+            ["https://filecrypt.cc/Container/ZZZ.html"],
         )
+
+    def test_direct_links_used_when_all_containers_red(self):
+        # Container badge is red, a direct-only hoster has a green badge: with no
+        # online container, fall through to the green direct link (tier 3).
+        releases = [
+            _release(
+                self.TITLE,
+                {"ddownload.com": ["https://ddownload.com/live"]},
+                {"rapidgator.net": "https://filecrypt.cc/Container/RED.html"},
+                check={
+                    "ddownload.com": "https://filecrypt.cc/Stat/GREEN.png",
+                    "rapidgator.net": "https://filecrypt.cc/Stat/RED.png",
+                },
+            )
+        ]
+        result = self._run(
+            releases,
+            online_badge_urls={"https://filecrypt.cc/Stat/GREEN.png"},
+        )
+        urls = [link[0] for link in result["links"]]
+        self.assertEqual(urls, ["https://ddownload.com/live"])
+
+    def test_tier4_first_red_when_nothing_online(self):
+        # Everything is offline-flagged. As a last resort the first red mirror
+        # is handed over (hide preferred), so the release is still attempted.
+        releases = [
+            _release(
+                self.TITLE,
+                {"ddownload.com": ["https://ddownload.com/a"]},
+                {
+                    "ddownload.com": "https://hide.cx/container/ZZ",
+                    "rapidgator.net": "https://filecrypt.cc/Container/BBB.html",
+                },
+                check={
+                    "ddownload.com": "https://filecrypt.cc/Stat/RED1.png",
+                    "rapidgator.net": "https://filecrypt.cc/Stat/RED2.png",
+                },
+            )
+        ]
+        # No badge URLs are online.
+        result = self._run(releases, online_badge_urls=set())
+        urls = [link[0] for link in result["links"]]
+        self.assertEqual(urls, ["https://hide.cx/container/ZZ"])
 
     def test_offline_hoster_is_dropped_but_online_kept(self):
         """
@@ -272,6 +333,64 @@ class WxDirectLinksTests(unittest.TestCase):
         result = self._run(releases)
         urls = [link[0] for link in result["links"]]
         self.assertEqual(urls, ["https://filecrypt.cc/Container/CCC.html"])
+
+    def test_does_not_merge_containers_across_mirrors(self):
+        # Two distinct mirrors each expose one online hide container. Only one
+        # mirror's set may be returned, never both merged - merging would
+        # enqueue duplicate copies of the same release in JDownloader.
+        m1 = _release(
+            self.TITLE,
+            {},
+            {"ddownload.com": "https://hide.cx/container/M1"},
+            check={"ddownload.com": "https://filecrypt.cc/Stat/M1.png"},
+        )
+        m2 = _release(
+            self.TITLE,
+            {},
+            {"rapidgator.net": "https://hide.cx/container/M2"},
+            check={"rapidgator.net": "https://filecrypt.cc/Stat/M2.png"},
+        )
+        result = self._run(
+            [m1, m2],
+            online_badge_urls={
+                "https://filecrypt.cc/Stat/M1.png",
+                "https://filecrypt.cc/Stat/M2.png",
+            },
+        )
+        urls = [link[0] for link in result["links"]]
+        self.assertEqual(len(urls), 1)
+        self.assertIn(
+            urls[0],
+            ["https://hide.cx/container/M1", "https://hide.cx/container/M2"],
+        )
+
+    def test_keeps_all_online_hosters_within_one_mirror(self):
+        # A single mirror with two online hide containers (different hosters)
+        # keeps both: redundant hoster choices for the same files are desired.
+        m = _release(
+            self.TITLE,
+            {},
+            {
+                "ddownload.com": "https://hide.cx/container/A",
+                "rapidgator.net": "https://hide.cx/container/B",
+            },
+            check={
+                "ddownload.com": "https://filecrypt.cc/Stat/A.png",
+                "rapidgator.net": "https://filecrypt.cc/Stat/B.png",
+            },
+        )
+        result = self._run(
+            [m],
+            online_badge_urls={
+                "https://filecrypt.cc/Stat/A.png",
+                "https://filecrypt.cc/Stat/B.png",
+            },
+        )
+        urls = sorted(link[0] for link in result["links"])
+        self.assertEqual(
+            urls,
+            ["https://hide.cx/container/A", "https://hide.cx/container/B"],
+        )
 
 
 if __name__ == "__main__":

--- a/uv.lock
+++ b/uv.lock
@@ -13,15 +13,15 @@ wheels = [
 
 [[package]]
 name = "beautifulsoup4"
-version = "4.14.3"
+version = "4.15.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "soupsieve" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c3/b0/1c6a16426d389813b48d95e26898aff79abbde42ad353958ad95cc8c9b21/beautifulsoup4-4.14.3.tar.gz", hash = "sha256:6292b1c5186d356bba669ef9f7f051757099565ad9ada5dd630bd9de5fa7fb86", size = 627737, upload-time = "2025-11-30T15:08:26.084Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/43/65/318323f98dbee45d42dff61d8f047181bc6f2268a9068cfad035a46be5af/beautifulsoup4-4.15.0.tar.gz", hash = "sha256:288e3ca7d54b06f2ac191970bc275c1939cb46d450b255bf6718b04aa37ab4f7", size = 632571, upload-time = "2026-06-07T16:44:20.453Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1a/39/47f9197bdd44df24d67ac8893641e16f386c984a0619ef2ee4c51fbbc019/beautifulsoup4-4.14.3-py3-none-any.whl", hash = "sha256:0918bfe44902e6ad8d57732ba310582e98da931428d231a5ecb9e7c703a735bb", size = 107721, upload-time = "2025-11-30T15:08:24.087Z" },
+    { url = "https://files.pythonhosted.org/packages/88/c6/92fcd42f1ba33e1184263f25bfabf3d27c383410470f169e4b8163bf9c17/beautifulsoup4-4.15.0-py3-none-any.whl", hash = "sha256:d6f88de62e1d4e38ecb1077eb9724cd0eff29d2a08ca16a401e9b9e93f117cf9", size = 109924, upload-time = "2026-06-07T16:44:21.566Z" },
 ]
 
 [[package]]
@@ -730,11 +730,11 @@ wheels = [
 
 [[package]]
 name = "wcwidth"
-version = "0.8.0"
+version = "0.8.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/af/44/c833e6b746ffb654e9abacf7ad6c2480a9c8c42e9637c1ae849964fb4dde/wcwidth-0.8.0.tar.gz", hash = "sha256:68a882ff6d14e3d14e0cae590b96a0551be64ce4905408112a8254434a1bdf69", size = 1305357, upload-time = "2026-06-05T21:19:35.667Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/49/b4/51fe890511f0f242d07cb1ebe6a5b6db417262b9d2568b460347c57d95cc/wcwidth-0.8.1.tar.gz", hash = "sha256:faf5b4a5366a72dc49cad48cdf21f52bdf63bdda995178e483ba247ff79089b9", size = 1466072, upload-time = "2026-06-08T05:57:23.146Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fb/17/c68b6cbcfeadbf420b3c3edaf8fda51335bc9c38732adb2d3ba8984dc607/wcwidth-0.8.0-py3-none-any.whl", hash = "sha256:8c75e6099cefd197c4bcc67a486f70b5dbc68f997c05f34a811d853910450d64", size = 324935, upload-time = "2026-06-05T21:19:33.999Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/6e/95b0e537de1f4d4301f76f944642c6da50d1511cc7b3d64dc418a66c7509/wcwidth-0.8.1-py3-none-any.whl", hash = "sha256:f453740b1e4a4f3291faa37944c555d71056c4da08d59809b307ef4feba695c8", size = 323092, upload-time = "2026-06-08T05:57:21.413Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## 🎯 What this does

Makes WX downloads reach JDownloader **online** far more often, and skips needless CAPTCHAs.

## The problem

A WX release offers several link sets: direct hoster links and crypted containers. Quasarr used to grab the **direct** links — but those are a separate upload that is often **already dead even while the release shows green**. JDownloader then gets a dead link and the download fails. ❌

## The fix 🔧

Quasarr now chooses links the way the WX site itself does, in order:

1. 🟢 **hide.cx container** — resolves automatically, no CAPTCHA
2. 🟢 **filecrypt container**
3. 🔗 **direct links** — only when no container is available
4. ♻️ if nothing reports online, still hand over the best mirror so it can fail cleanly and Radarr/Sonarr move on to the next release

On top of that: for releases that WX also publishes on hide.cx, Quasarr uses that copy so it resolves **without a CAPTCHA** — exactly what clicking the button on the WX site does. This recovers a large share (~30%) of downloads that used to fail. ✅

Quasarr still never pings hoster links itself to test if they're alive — that stays JDownloader's job.

## Notes

- 🧪 Fully covered by tests
- 📄 New `docs/Mirror-Selection.md` explains the policy
- 🐛 Minor: a DT log line for a missing file size is now debug instead of a warning