### PR TITLE
fix: detect not downloadable links

### DIFF
--- a/quasarr/constants/__init__.py
+++ b/quasarr/constants/__init__.py
@@ -416,6 +416,11 @@ EXTRACTION_COMPLETE_MARKERS = (
     "entpacken ok",  # German
 )
 
+# Status Strings from JDownloader (add more languages if needed)
+NOT_DOWNLOADABLE_MARKERS = (
+    "not downloadable",  # English
+)
+
 # Used during archive detection
 ARCHIVE_EXTENSIONS = frozenset(
     [

--- a/quasarr/downloads/packages/__init__.py
+++ b/quasarr/downloads/packages/__init__.py
@@ -11,6 +11,7 @@ from urllib.parse import urlparse
 from quasarr.constants import (
     ARCHIVE_EXTENSIONS,
     EXTRACTION_COMPLETE_MARKERS,
+    NOT_DOWNLOADABLE_MARKERS,
     PACKAGE_ID_PATTERN,
 )
 from quasarr.providers.jd_cache import JDPackageCache
@@ -28,6 +29,14 @@ def is_extraction_complete(status):
         return False
     status_lower = status.lower()
     return any(marker in status_lower for marker in EXTRACTION_COMPLETE_MARKERS)
+
+
+def is_not_downloadable(status):
+    """Check if a JDownloader status string marks a link as not downloadable (case-insensitive)."""
+    if not status:
+        return False
+    status_lower = status.lower()
+    return any(marker in status_lower for marker in NOT_DOWNLOADABLE_MARKERS)
 
 
 def is_archive_file(filename, extraction_status=""):
@@ -114,7 +123,9 @@ def get_links_status(package, all_links, is_archive=False):
     has_mirror_all_online = False
     for domain, mirror_links in mirrors.items():
         if all(
-            link.get("availability", "").lower() == "online" for link in mirror_links
+            link.get("availability", "").lower() == "online"
+            and not is_not_downloadable(link.get("status"))
+            for link in mirror_links
         ):
             has_mirror_all_online = True
             debug(f"Mirror '{domain}' has all {len(mirror_links)} links online")
@@ -153,6 +164,9 @@ def get_links_status(package, all_links, is_archive=False):
         link_status_icon = link.get("statusIconKey", "").lower()
         link_eta = link.get("eta", 0) // 1000 if link.get("eta") else 0
 
+        if is_not_downloadable(link_status):
+            link_availability = "not downloadable"
+
         # Determine if THIS LINK is an archive file
         link_is_archive_file = is_archive_file(link_name, link_extraction_status)
 
@@ -167,9 +181,14 @@ def get_links_status(package, all_links, is_archive=False):
         )
 
         # Check for offline links
-        if link_availability == "offline" and not has_mirror_all_online:
-            error = "Links offline for all mirrors"
-            debug(f"ERROR - Link offline with no online mirror: {link_name}")
+        if (
+            link_availability in ["offline", "not downloadable"]
+            and not has_mirror_all_online
+        ):
+            error = f"Links {link_availability} for all mirrors"
+            debug(
+                f"ERROR - Link {link_availability} with no online mirror: {link_name}"
+            )
 
         # Check for file errors
         if link_status_icon == "false":

--- a/quasarr/providers/version.py
+++ b/quasarr/providers/version.py
@@ -5,7 +5,7 @@
 import re
 import sys
 
-__version__ = "4.5.7"
+__version__ = "4.5.8"
 
 
 def get_version():

--- a/tests/test_package_link_status.py
+++ b/tests/test_package_link_status.py
@@ -1,0 +1,80 @@
+# -*- coding: utf-8 -*-
+
+import unittest
+
+from quasarr.downloads.packages import get_links_status, is_not_downloadable
+
+PACKAGE = {"uuid": 1, "name": "Synthetic.Release.Example"}
+
+
+def make_link(uuid, url, availability="ONLINE", status="", finished=False):
+    return {
+        "uuid": uuid,
+        "packageUUID": 1,
+        "name": f"file-{uuid}.mkv",
+        "url": url,
+        "availability": availability,
+        "status": status,
+        "finished": finished,
+    }
+
+
+class IsNotDownloadableTests(unittest.TestCase):
+    def test_matches_status_case_insensitively(self):
+        self.assertTrue(is_not_downloadable("Not downloadable!"))
+        self.assertTrue(is_not_downloadable("NOT DOWNLOADABLE! (Premium needed)"))
+
+    def test_ignores_other_or_missing_status(self):
+        self.assertFalse(is_not_downloadable("Extraction OK"))
+        self.assertFalse(is_not_downloadable(""))
+        self.assertFalse(is_not_downloadable(None))
+
+
+class GetLinksStatusNotDownloadableTests(unittest.TestCase):
+    def test_all_mirrors_not_downloadable_sets_error(self):
+        links = [
+            make_link(11, "http://mirror-a.invalid/f1", status="Not downloadable!"),
+            make_link(12, "http://mirror-a.invalid/f2", status="Not downloadable!"),
+        ]
+
+        result = get_links_status(PACKAGE, links)
+
+        self.assertEqual(result["error"], "Links not downloadable for all mirrors")
+        self.assertFalse(result["all_finished"])
+
+    def test_not_downloadable_mirror_does_not_count_as_online(self):
+        links = [
+            make_link(11, "http://mirror-a.invalid/f1", availability="OFFLINE"),
+            make_link(21, "http://mirror-b.invalid/f1", status="Not downloadable!"),
+        ]
+
+        result = get_links_status(PACKAGE, links)
+
+        self.assertIn("for all mirrors", result["error"])
+        self.assertEqual(result["offline_mirror_linkids"], [])
+
+    def test_online_mirror_suppresses_not_downloadable_error(self):
+        links = [
+            make_link(11, "http://mirror-a.invalid/f1", finished=True),
+            make_link(21, "http://mirror-b.invalid/f1", status="Not downloadable!"),
+        ]
+
+        result = get_links_status(PACKAGE, links)
+
+        self.assertIsNone(result["error"])
+        self.assertFalse(result["all_finished"])
+
+    def test_offline_links_collected_for_cleanup_with_online_mirror(self):
+        links = [
+            make_link(11, "http://mirror-a.invalid/f1", finished=True),
+            make_link(21, "http://mirror-b.invalid/f1", availability="OFFLINE"),
+        ]
+
+        result = get_links_status(PACKAGE, links)
+
+        self.assertIsNone(result["error"])
+        self.assertEqual(result["offline_mirror_linkids"], [21])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Currently Quasarr pauses forever on not downloadable links, instead of marking them as failed so that another release can be picked. This change expands the offline link logic to include not downloadable links as well.