### PR TITLE
feat: Added support for daily/date searches

### DIFF
--- a/quasarr/providers/utils.py
+++ b/quasarr/providers/utils.py
@@ -1053,6 +1053,9 @@ def is_valid_release(
     search_string: str,
     season: int = None,
     episode: int = None,
+    episode_year: int = None,
+    episode_month: int = None,
+    episode_day: int = None,
 ) -> bool:
     """
     Return True if the given release title is valid for the given search parameters.
@@ -1092,24 +1095,41 @@ def is_valid_release(
 
         # if it's a TV show search, don't allow any movies (check for season or episode tags in the title)
         if is_tv_search:
-            # must have some S/E tag present
-            if not SEASON_EP_REGEX.search(title):
-                trace(
-                    "Skipping {title!r} as title doesn't match TV show regex: {pattern!r}",
-                    title=title,
-                    pattern=SEASON_EP_REGEX.pattern,
-                )
-                return False
-            # if caller specified a season or episode, double‑check the match
-            if season is not None or episode is not None:
-                if not match_in_title(title, season, episode):
+            if episode_year is None:
+                # must have some S/E tag present
+                if not SEASON_EP_REGEX.search(title):
                     trace(
-                        "Skipping {title!r} as it doesn't match season {season} and episode {episode}",
+                        "Skipping {title!r} as title doesn't match TV show regex: {pattern!r}",
                         title=title,
-                        season=season,
-                        episode=episode,
+                        pattern=SEASON_EP_REGEX.pattern,
                     )
                     return False
+                # if caller specified a season or episode, double‑check the match
+                if season is not None or episode is not None:
+                    if not match_in_title(title, season, episode):
+                        trace(
+                            "Skipping {title!r} as it doesn't match season {season} and episode {episode}",
+                            title=title,
+                            season=season,
+                            episode=episode,
+                        )
+                        return False
+
+            else:
+                if (
+                    episode_year not in title
+                    or episode_month not in title
+                    or episode_day not in title
+                ):
+                    trace(
+                        "Skipping {title!r} as it doesn't match date {episode_year}-{episode_month}-{episode_day}",
+                        title=title,
+                        episode_year=episode_year,
+                        episode_month=episode_month,
+                        episode_day=episode_day,
+                    )
+                    return False
+
             return True
 
         # if it's a document search, it should not contain Movie or TV show tags

--- a/quasarr/providers/version.py
+++ b/quasarr/providers/version.py
@@ -5,7 +5,7 @@
 import re
 import sys
 
-__version__ = "4.5.8"
+__version__ = "4.5.9"
 
 
 def get_version():

--- a/quasarr/search/__init__.py
+++ b/quasarr/search/__init__.py
@@ -55,6 +55,17 @@ def get_search_results(
     if imdb_id:
         get_imdb_metadata(imdb_id)
 
+    episode_year = None
+    episode_month = None
+    episode_day = None
+    if "/" in episode:
+        episode_date_raw = episode.split("/")
+        episode_year = season
+        episode_month = episode_date_raw[0]
+        episode_day = episode_date_raw[1]
+        episode = None
+        season = None
+
     # Determine search category if not provided
     if not search_category:
         search_category = determine_search_category(request_from)
@@ -106,10 +117,21 @@ def get_search_results(
             stype += f" <g>S{season}</g>"
         if episode:
             stype += f"{'' if season else ' '}<e>E{episode}</e>"
+        if episode_year:
+            stype += (
+                f" <g>{episode_year}</g>-<e>{episode_month}</e>-<y>{episode_day}</y>"
+            )
 
         if base_search_category in [SEARCH_CAT_MOVIES, SEARCH_CAT_SHOWS]:
             args = (shared_state, start_time, behavior_search_category)
-            kwargs = {"search_string": imdb_id, "season": season, "episode": episode}
+            kwargs = {
+                "search_string": imdb_id,
+                "season": season,
+                "episode": episode,
+                "episode_year": episode_year,
+                "episode_month": episode_month,
+                "episode_day": episode_day,
+            }
             for source in sources.values():
                 source_logger = get_source_logger(source.initials)
 
@@ -135,6 +157,10 @@ def get_search_results(
 
                 if episode and not season and not source.supports_absolute_numbering:
                     source_logger.trace("Search with absolute EP number unsupported")
+                    continue
+
+                if episode_year and not source.supports_date_numbering:
+                    source_logger.trace("Search with date unsupported")
                     continue
 
                 search_executor.add(

--- a/quasarr/search/sources/dl.py
+++ b/quasarr/search/sources/dl.py
@@ -53,6 +53,7 @@ class Source(AbstractSearchSource):
         SEARCH_CAT_BOOKS,
     ]
     requires_login = True
+    supports_date_numbering = True
 
     def feed(
         self, shared_state: shared_state, start_time: float, search_category: str
@@ -188,6 +189,9 @@ class Source(AbstractSearchSource):
         search_category,
         season,
         episode,
+        episode_year,
+        episode_month,
+        episode_day,
     ):
         """
         Search a single page. This method is called sequentially for each page.
@@ -282,6 +286,9 @@ class Source(AbstractSearchSource):
                         search_string,
                         season,
                         episode,
+                        episode_year,
+                        episode_month,
+                        episode_day,
                     ):
                         continue
 
@@ -353,6 +360,9 @@ class Source(AbstractSearchSource):
         search_string: str = "",
         season: int = None,
         episode: int = None,
+        episode_year: int = None,
+        episode_month: int = None,
+        episode_day: int = None,
     ) -> list[SearchRelease]:
         """
         Search with sequential pagination to find best quality releases.
@@ -368,9 +378,13 @@ class Source(AbstractSearchSource):
                 info(f"no title for IMDb {imdb_id}")
                 return releases
             search_string = title
-            if not season:
-                if year := get_year(imdb_id):
-                    search_string += f" {year}"
+
+            if not episode_year:
+                if not season:
+                    if year := get_year(imdb_id):
+                        search_string += f" {year}"
+            else:
+                search_string += f" {episode_year} {episode_month} {episode_day}"
 
         search_string = unescape(search_string)
         max_search_duration = 7
@@ -404,6 +418,9 @@ class Source(AbstractSearchSource):
                     search_category,
                     season,
                     episode,
+                    episode_year,
+                    episode_month,
+                    episode_day,
                 )
 
                 page_release_titles = tuple(

--- a/quasarr/search/sources/helpers/search_source.py
+++ b/quasarr/search/sources/helpers/search_source.py
@@ -25,6 +25,10 @@ class AbstractSearchSource(ABC):
         return False
 
     @property
+    def supports_date_numbering(self) -> bool:
+        return False
+
+    @property
     @abstractmethod
     def supported_categories(self) -> list[int]:
         pass
@@ -50,6 +54,9 @@ class AbstractSearchSource(ABC):
         search_string: str = "",
         season: int = None,
         episode: int = None,
+        episode_year: int = None,
+        episode_month: int = None,
+        episode_day: int = None,
     ) -> list[SearchRelease]:
         pass
 

--- a/uv.lock
+++ b/uv.lock
@@ -35,11 +35,11 @@ wheels = [
 
 [[package]]
 name = "certifi"
-version = "2026.5.20"
+version = "2026.6.17"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/f3/ce/ee2ecad540810a79593028e88299baeae54d346cc7a0d94b6199988b89b1/certifi-2026.5.20.tar.gz", hash = "sha256:69dea482ab64caa7b9f6aba1c6bf48bb6a5448d1c0f1b17ab42ad8c763a5344d", size = 135422, upload-time = "2026-05-20T11:46:50.073Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c9/c7/424b75da314c1045981bd9777432fad05a9e0c69daa4ed7e308bbaffe405/certifi-2026.6.17.tar.gz", hash = "sha256:024c88eeec92ca068db80f02b8b07c9cef7b9fe261d1d535abfd5abd6f6af432", size = 134594, upload-time = "2026-06-17T10:31:07.894Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/59/8c/57e832b7af6d7c5abe66eb3fbe3a3a32f4d11ea23a1aa7131371035be991/certifi-2026.5.20-py3-none-any.whl", hash = "sha256:3c52e209ba0a4ad7aebe60436a4ab349c39e1e602e8c134221e546902ad25897", size = 134134, upload-time = "2026-05-20T11:46:48.578Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/2f/c5464532e965badff2f4c4c1a3a83f5697f0d7c407ed0cda44aaa99bb451/certifi-2026.6.17-py3-none-any.whl", hash = "sha256:2227dcbaafe0d2f59279d1762ddddc37783ed4354594f194ffc31d20f41fc3db", size = 133289, upload-time = "2026-06-17T10:31:06.348Z" },
 ]
 
 [[package]]
@@ -714,7 +714,7 @@ wheels = [
 
 [[package]]
 name = "virtualenv"
-version = "21.5.0"
+version = "21.5.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "distlib" },
@@ -722,9 +722,9 @@ dependencies = [
     { name = "platformdirs" },
     { name = "python-discovery" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/cd/0e/933bacb37b57ae7928b0030eef205a3dbb3e37afdbdde5be2e113318958f/virtualenv-21.5.0.tar.gz", hash = "sha256:98847aadf5e2037e0e4d2e19528eb3aca6f23906422e59a510bff231a6d32fce", size = 4577424, upload-time = "2026-06-13T20:36:45.066Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f1/a5/81f987504738e6defeed61ec1c47e2aefab3c35d8eeb87e1b3f38cf28254/virtualenv-21.5.1.tar.gz", hash = "sha256:dca3bf98275a59c652b69d68e73433e597d977c2da9198882479d1a7188009c8", size = 4578798, upload-time = "2026-06-16T16:23:58.603Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e9/87/b0667ede418386ab631e48924b845d326f366d61e6bd08fe68a748fae4d4/virtualenv-21.5.0-py3-none-any.whl", hash = "sha256:8f7c38605023688c89789f566959006af6d61c99eeeb9e58342eb780c5761e5e", size = 4557937, upload-time = "2026-06-13T20:36:42.967Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/02/3623e6169bed617ed1e2d372f7c69f92ec28d54c4dfc997055c8578ec148/virtualenv-21.5.1-py3-none-any.whl", hash = "sha256:55aa670b67bbfb991b03fda39bd3276d92c419d702376e98c5df1c9989a26783", size = 4558820, upload-time = "2026-06-16T16:23:56.963Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
When an episode containing "/" is searched for by Sonarr, then Quasarr recognizes this to be a "Daily/Date" search where Sonarr searches with `season`=YEAR and `episode`=MONTH/DAY.
Quasarr clears `season` and `episode` and instead provides three new fields `episode_year`, `episode_month` and `epsiode_day` to be used for searches per source.

Quasarr will now respect this as a dedicated search mode, skipping any source that does not support it.

Additionally I added preliminary support to DL for "Daily/Date" searches, however I doubt the implementation for DL is already finished/done. I got some results in my tests on DL, however Sonarr rejects a lot of Daily/Date releases from DL due to their naming conventions - further work will probably be needed to get this working well with DL.