### PR TITLE
[Antipattern/Won't fix] Try to identify episode files via filename

### DIFF
--- a/quasarr/downloads/AGENTS.md
+++ b/quasarr/downloads/AGENTS.md
@@ -7,6 +7,7 @@ Receives a grab request from the SABnzbd-emulating API, picks the matching sourc
 ## Ownership
 
 - `__init__.py` — orchestrator: source selection, link classification, package IDs, the `submit_final_download_urls()` funnel, `fail()` bookkeeping
+- `episode_links.py` — trims a single-episode package down to the requested episode inside the linkgrabber
 - `mirror_filters.py` — canonical mirror-token normalization and the final pre-JDownloader whitelist filter
 - `packages/` — SABnzbd-shaped queue/history aggregation, archive/extraction tracking, auto-start, deletion
 - `sources/` and `linkcrypters/` — see Child DOX Index
@@ -22,6 +23,7 @@ Receives a grab request from the SABnzbd-emulating API, picks the matching sourc
 - Protected-package JSON owns the tracked notification references for that release; no separate notification table exists. `submit_final_download_urls(..., remove_protected=True)` captures this context before deletion, edits the original notification on solved/failed outcomes, and accepts `notification_details` so manual and SponsorsHelper solutions render accurately.
 - `fail()` deliberately returns `{"success": True, "failed": True}` so the *arr client records the grab and can blocklist it.
 - `packages/` auto-start moves exactly ONE Quasarr package per call from linkgrabber to the download list; archive packages are only "finished" when extraction completed; `nzo_id` is the Quasarr package ID read from the JD `comment` field (JD uuid fallback for foreign packages).
+- Single-episode trimming (`episode_links.py`) runs inside that auto-start, right before a package is moved: crypter containers are season-wide, so a single-episode grab can arrive carrying the whole season (paths that read a container as a whole — notably the userscript flow — return every episode, unlike `get_filecrypt_links`, which narrows it via the season/episode parameters it derives from the title). Link URLs carry no file names, so the linkgrabber is the earliest point the mismatch is visible. The JD package name is authoritative (`download_package` sets `packageName` to the release title and passes `overwritePackagizerRules`); when it names a single episode, links whose file name belongs to another episode of that season are removed via `linkgrabber.remove_links(ids, [])` (package_ids MUST stay empty) and the start is deferred to the next pass. Safety invariant: a season-pack name, any unmappable link (no/ambiguous marker, season mismatch, missing uuid), or a plan that would keep or remove everything leaves the package untouched — downloading too much is wasteful, downloading too little breaks the import.
 - Sources call `mark_hostname_issue(initials, "download", msg)` on errors; the orchestrator clears the issue when a source returns usable links.
 
 ### Mirror-Selection Policy

--- a/quasarr/downloads/episode_links.py
+++ b/quasarr/downloads/episode_links.py
@@ -1,0 +1,124 @@
+# -*- coding: utf-8 -*-
+# Quasarr
+# Project by https://github.com/rix1337
+
+"""Trim a single-episode package down to the episode that was requested.
+
+Grabbing one episode can still hand Quasarr the links of a whole season.
+Crypter containers are season wide; Filecrypt only narrows them down when the
+decrypting side asks for it explicitly (`get_filecrypt_links` does, via the
+season/episode parameters it derives from the release title). Paths that read
+a container as a whole - most notably the userscript flow - return every
+episode. JDownloader then holds a full season under a package whose name names
+exactly one episode, and the *arr client imports one file while the rest is
+downloaded for nothing.
+
+Link URLs carry no file names, so the mismatch is invisible until JDownloader
+has collected the package. That makes the linkgrabber the earliest - and only -
+place where it can be corrected.
+
+The package name is authoritative: `download_package` sets it to the release
+title and passes `overwritePackagizerRules`, so JDownloader cannot rename it.
+
+Safety first: whenever the links cannot be mapped to episodes unambiguously,
+the package is left untouched. Downloading too much is wasteful; downloading
+too little breaks the import.
+"""
+
+import re
+
+from quasarr.providers.log import info
+
+# Season/episode token in release titles and archive file names, e.g.
+# "Pack.S01.German..." (no episode part) or "pack.s01e05.german...part03.rar".
+# Ranges like "S01E01-E03" are captured whole and expanded by the parser.
+_SEASON_TOKEN = re.compile(
+    r"(?<![a-z0-9])S(?P<season>\d{1,4})(?P<episodes>(?:E\d{1,4})+(?:-E?\d{1,4})?)?(?![a-z0-9])",
+    re.IGNORECASE,
+)
+
+
+def parse_season_episodes(name):
+    """Parse the first season/episode token from a title or file name.
+
+    Returns ``(season, episode_numbers)`` where ``episode_numbers`` is a set
+    (empty for a season pack without an episode component), or ``None`` when
+    the name carries no season token at all.
+    """
+    match = _SEASON_TOKEN.search(name or "")
+    if not match:
+        return None
+    season = int(match.group("season"))
+    episode_part = match.group("episodes") or ""
+    numbers = [int(n) for n in re.findall(r"\d{1,4}", episode_part)]
+    if not numbers:
+        return season, set()
+    if (
+        "-" in episode_part
+        and len(numbers) == 2
+        and numbers[0] < numbers[1]
+        and numbers[1] - numbers[0] <= 100
+    ):
+        return season, set(range(numbers[0], numbers[1] + 1))
+    return season, set(numbers)
+
+
+def plan_link_removals(package_name, links):
+    """Split links into (keep_ids, remove_ids), or None to keep the package as is.
+
+    ``links`` are linkgrabber link dicts carrying ``uuid`` and ``name``.
+    Returns ``None`` - keep everything - when the package name names no single
+    episode (a season pack was requested), when any link cannot be mapped to an
+    episode of that season, or when filtering would remove nothing or keep
+    nothing.
+    """
+    parsed_package = parse_season_episodes(package_name)
+    if not parsed_package:
+        return None
+    season, requested = parsed_package
+    if not requested:
+        return None  # season pack: every episode belongs to this grab
+
+    keep, remove = [], []
+    for link in links:
+        uuid = link.get("uuid")
+        if uuid is None:
+            return None
+        parsed_link = parse_season_episodes(link.get("name") or "")
+        if not parsed_link or not parsed_link[1] or parsed_link[0] != season:
+            return None  # unmapped link -> never risk an incomplete download
+        if parsed_link[1] & requested:
+            keep.append(uuid)
+        else:
+            remove.append(uuid)
+
+    if not keep or not remove:
+        return None
+    return keep, remove
+
+
+def trim_to_requested_episodes(shared_state, package_name, package_links):
+    """Remove links of other episodes from a single-episode package.
+
+    Returns True when links were removed, so the caller can postpone the start
+    until JDownloader's state has settled. Once trimmed, a later pass finds
+    nothing to remove and the package starts normally.
+    """
+    plan = plan_link_removals(package_name, package_links)
+    if plan is None:
+        return False
+
+    keep, remove = plan
+    try:
+        # package_ids must stay empty: passing the package id would remove the
+        # whole package instead of only the filtered links.
+        shared_state.get_device().linkgrabber.remove_links(remove, [])
+    except Exception as e:
+        info(f"Could not trim '{package_name}' to the requested episode: {e}")
+        return False
+
+    info(
+        f"Removed <g>{len(remove)}</g> link(s) belonging to other episodes from "
+        f"'{package_name}', keeping <g>{len(keep)}</g>"
+    )
+    return True

--- a/quasarr/downloads/packages/__init__.py
+++ b/quasarr/downloads/packages/__init__.py
@@ -14,6 +14,7 @@ from quasarr.constants import (
     NOT_DOWNLOADABLE_MARKERS,
     PACKAGE_ID_PATTERN,
 )
+from quasarr.downloads.episode_links import trim_to_requested_episodes
 from quasarr.providers.jd_cache import JDPackageCache
 from quasarr.providers.log import debug, info, trace
 from quasarr.storage.categories import get_download_category_from_package_id
@@ -766,10 +767,21 @@ def get_packages(shared_state, _cache=None, auto_start=True):
             if is_quasarr_package(comment):
                 package_uuid = package.get("uuid")
                 if package_uuid:
-                    package_link_ids = [
-                        link.get("uuid")
+                    package_links = [
+                        link
                         for link in linkgrabber_links
-                        if link.get("packageUUID") == package_uuid and link.get("uuid")
+                        if link.get("packageUUID") == package_uuid
+                    ]
+                    # A single-episode grab can still carry a whole season's
+                    # links. File names are known now, so drop the other
+                    # episodes before the package starts; when links were
+                    # removed, start on the next pass so JD's state settles.
+                    if trim_to_requested_episodes(
+                        shared_state, package.get("name"), package_links
+                    ):
+                        break
+                    package_link_ids = [
+                        link.get("uuid") for link in package_links if link.get("uuid")
                     ]
                     if package_link_ids:
                         debug(

--- a/quasarr/providers/log.py
+++ b/quasarr/providers/log.py
@@ -66,6 +66,7 @@ _context_replace = {
     "config": "⚙️",  # /quasarr/api/config/*
     "sponsors_helper": "💖",  # /quasarr/api/sponsors_helper/*
     "downloads": "📥",  # /quasarr/downloads/*
+    "episode_links": "🎯",  # /quasarr/downloads/episode_links.py
     "linkcrypters": "🔐",  # /quasarr/linkcrypters/*
     "filecrypt": "🛡️",  # /quasarr/linkcrypters/filecrypt.py
     "hide": "👻",  # /quasarr/linkcrypters/hide.py

--- a/quasarr/providers/version.py
+++ b/quasarr/providers/version.py
@@ -5,7 +5,7 @@
 import re
 import sys
 
-__version__ = "4.6.8"
+__version__ = "4.6.9"
 
 
 def get_version():

--- a/tests/test_episode_links.py
+++ b/tests/test_episode_links.py
@@ -1,0 +1,144 @@
+import unittest
+from unittest.mock import MagicMock
+
+from quasarr.downloads import episode_links
+
+
+def link(uuid, name):
+    return {"uuid": uuid, "name": name, "packageUUID": 1000}
+
+
+# A single-episode grab that carried the whole season: the package is named
+# after episode 2, but the links cover episodes 1 to 3. Multipart archives per
+# episode are the shape this exists for. Synthetic titles only.
+SEASON_LINKS = [
+    link(1, "synthetic.show.s01e01.german.web-grp.part01.rar"),
+    link(2, "synthetic.show.s01e01.german.web-grp.part02.rar"),
+    link(3, "synthetic.show.s01e02.german.web-grp.part01.rar"),
+    link(4, "synthetic.show.s01e02.german.web-grp.part02.rar"),
+    link(5, "synthetic.show.s01e03.german.web-grp.part01.rar"),
+]
+
+EPISODE_PACKAGE = "Synthetic.Show.S01E02.German.DL.1080p.WEB.h264-GRP"
+SEASON_PACKAGE = "Synthetic.Show.S01.German.DL.1080p.WEB.h264-GRP"
+
+
+class ParseSeasonEpisodesTests(unittest.TestCase):
+    def test_parses_titles_and_filenames(self):
+        cases = [
+            # Season pack: season token, no episode component.
+            ("Synthetic.Show.S01.German.1080p.WEB-GRP", (1, set())),
+            # Single episode, as release title and as archive file name.
+            ("Synthetic.Show.S01E05.German.1080p.WEB-GRP", (1, {5})),
+            ("synthetic.show.s01e05.german.web-grp.part03.rar", (1, {5})),
+            # Repack markers after the token do not disturb parsing.
+            ("synthetic.show.s01e06.german.web.repack-grp.part01.rar", (1, {6})),
+            # Ranges expand to every contained episode.
+            ("Synthetic.Show.S01E01-E03.German.1080p.WEB-GRP", (1, {1, 2, 3})),
+            ("Synthetic.Show.S01E01-03.German.1080p.WEB-GRP", (1, {1, 2, 3})),
+            # Multi-episode files without a range dash keep both numbers.
+            ("Synthetic.Show.S01E01E02.German.1080p.WEB-GRP", (1, {1, 2})),
+            # No season token at all (a movie).
+            ("Synthetic.Movie.2024.German.1080p.BluRay-GRP", None),
+            # "part11" must not be mistaken for an episode marker.
+            ("synthetic.show.s02.german.web-grp.part11.rar", (2, set())),
+        ]
+        for name, expected in cases:
+            with self.subTest(name=name):
+                self.assertEqual(episode_links.parse_season_episodes(name), expected)
+
+
+class PlanLinkRemovalsTests(unittest.TestCase):
+    def test_keeps_only_the_requested_episode(self):
+        plan = episode_links.plan_link_removals(EPISODE_PACKAGE, SEASON_LINKS)
+
+        self.assertEqual(plan, ([3, 4], [1, 2, 5]))
+
+    def test_season_pack_is_left_untouched(self):
+        # Every episode belongs to a season-pack grab; nothing to trim.
+        self.assertIsNone(
+            episode_links.plan_link_removals(SEASON_PACKAGE, SEASON_LINKS)
+        )
+
+    def test_already_matching_package_is_left_untouched(self):
+        # All links are the requested episode -> nothing to remove.
+        matching = [link_ for link_ in SEASON_LINKS if "s01e02" in link_["name"]]
+
+        self.assertIsNone(episode_links.plan_link_removals(EPISODE_PACKAGE, matching))
+
+    def test_unparseable_link_keeps_the_package(self):
+        # A single unmappable link poisons the mapping: keep everything rather
+        # than risk removing a file that belongs to the wanted episode.
+        links = SEASON_LINKS + [link(6, "synthetic.show.sample.mkv")]
+
+        self.assertIsNone(episode_links.plan_link_removals(EPISODE_PACKAGE, links))
+
+    def test_season_mismatch_keeps_the_package(self):
+        links = SEASON_LINKS + [link(6, "synthetic.show.s02e02.german.web-grp.rar")]
+
+        self.assertIsNone(episode_links.plan_link_removals(EPISODE_PACKAGE, links))
+
+    def test_link_without_uuid_keeps_the_package(self):
+        links = [dict(SEASON_LINKS[0]), dict(SEASON_LINKS[2])]
+        links[0].pop("uuid")
+
+        self.assertIsNone(episode_links.plan_link_removals(EPISODE_PACKAGE, links))
+
+    def test_nothing_of_the_requested_episode_present_keeps_the_package(self):
+        # Requested episode is absent -> keeping nothing would empty the
+        # package, so leave it alone and let the normal flow deal with it.
+        self.assertIsNone(
+            episode_links.plan_link_removals(
+                "Synthetic.Show.S01E09.German.DL.1080p.WEB.h264-GRP", SEASON_LINKS
+            )
+        )
+
+    def test_episode_range_package_keeps_every_contained_episode(self):
+        plan = episode_links.plan_link_removals(
+            "Synthetic.Show.S01E01-E02.German.DL.1080p.WEB.h264-GRP", SEASON_LINKS
+        )
+
+        self.assertEqual(plan, ([1, 2, 3, 4], [5]))
+
+
+def shared_state_with(device):
+    return MagicMock(get_device=MagicMock(return_value=device))
+
+
+class TrimToRequestedEpisodesTests(unittest.TestCase):
+    def test_removes_other_episodes_and_reports_removal(self):
+        device = MagicMock()
+
+        removed = episode_links.trim_to_requested_episodes(
+            shared_state_with(device), EPISODE_PACKAGE, SEASON_LINKS
+        )
+
+        self.assertTrue(removed)
+        # package_ids must stay empty; passing the package id would remove the
+        # whole package instead of only the filtered links.
+        device.linkgrabber.remove_links.assert_called_once_with([1, 2, 5], [])
+
+    def test_season_pack_is_a_noop(self):
+        device = MagicMock()
+
+        removed = episode_links.trim_to_requested_episodes(
+            shared_state_with(device), SEASON_PACKAGE, SEASON_LINKS
+        )
+
+        self.assertFalse(removed)
+        device.linkgrabber.remove_links.assert_not_called()
+
+    def test_device_error_keeps_the_package(self):
+        device = MagicMock()
+        device.linkgrabber.remove_links.side_effect = RuntimeError("jd gone")
+
+        removed = episode_links.trim_to_requested_episodes(
+            shared_state_with(device), EPISODE_PACKAGE, SEASON_LINKS
+        )
+
+        # Reported as "not removed" so the caller starts the package as before.
+        self.assertFalse(removed)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- trim a linkgrabber package down to the episode its name asks for, right before auto-start moves it to the download list
- keep the package untouched whenever its links cannot be mapped to episodes unambiguously
- add coverage for season/episode parsing, the trimming plan, and the JDownloader call
- bump Quasarr to 4.6.9

This fix was written with [Claude Code](https://claude.com/claude-code). Root cause, fix, and tests were reviewed and verified against a live instance before submitting.

## Root cause

Crypter containers are season wide. `get_filecrypt_links` narrows them down via the `season=`/`episode=` parameters it derives from the release title, but paths that read a container as a whole do not — most notably the userscript flow, which posts back every link it finds. Filecrypt filters its *display* for a container URL carrying `?season=&episode=`, yet the CNL form and the DLC blob behind it still hold the whole season.

The result: a grab for one episode becomes a JDownloader package named after that episode while containing the whole season. Sonarr imports the one file it asked for; the rest was downloaded for nothing.

This cannot be fixed where the links arrive — they are plain hoster URLs carrying no file names. File names only exist once JDownloader has collected the package, which makes the linkgrabber the earliest and only place the mismatch is visible.

## Impact

When a Quasarr package in the linkgrabber is named after a single episode and its collected links cover other episodes of the same season, those links are removed before the package starts. The start is deferred to the next pass so JDownloader's state settles; once trimmed, nothing is left to remove and it starts normally.

The package name is authoritative: `download_package` sets `packageName` to the release title and passes `overwritePackagizerRules`, so JDownloader cannot rename it out from under this check.

Season-pack grabs are unaffected — their name carries no episode component, so every episode legitimately belongs to the grab. Movies never match the season token at all.

Nothing is removed unless the mapping is unambiguous. A single link without a parseable episode marker, a link from another season, a missing link uuid, or a plan that would keep or remove everything all leave the package untouched. Downloading too much is wasteful; downloading too little breaks the import, so the safe direction is always "keep".

No configuration, hostname, or environment-variable changes.

## Proof

- live verification on a real instance via the userscript flow: a single-episode grab whose container held two episodes was trimmed from 10 links to 5 before start; only the requested episode was downloaded, extracted and imported
- a removal only happens when every link maps cleanly to an episode of the package's season, so the trimmed set is provably the requested episode rather than a best guess
- confirmed in `download_package` that the package name is the release title and packagizer rules are overridden, so the name cannot drift to a file-derived one
- the season-pack, unmappable-link, season-mismatch, missing-uuid and nothing-to-do cases are covered as explicit "keep the package" assertions, pinning the safe direction rather than only the happy path
- `uv run python -X utf8 pre-commit.py`: 275 tests passed; Ruff check and formatting passed
